### PR TITLE
Add resin.models.device.getByUUID

### DIFF
--- a/build/models/device.js
+++ b/build/models/device.js
@@ -223,8 +223,8 @@
     if (uuid == null) {
       throw new errors.ResinMissingParameter('uuid');
     }
-    if (!_.isString(name)) {
-      throw new errors.ResinInvalidParameter('uuid', name, 'not a string');
+    if (!_.isString(uuid)) {
+      throw new errors.ResinInvalidParameter('uuid', uuid, 'not a string');
     }
     if (callback == null) {
       throw new errors.ResinMissingParameter('callback');

--- a/build/models/device.js
+++ b/build/models/device.js
@@ -205,6 +205,60 @@
 
 
   /**
+   * @summary Get a single device by UUID
+   * @public
+   * @function
+   *
+   * @param {String} uuid - device UUID
+   * @param {module:resin.models.device~getCallback} callback - callback
+   *
+   * @example
+   *	resin.models.device.get '7cf02a62a3a84440b1bb5579a3d57469148943278630b17e7fc6c4f7b465c9', (error, device) ->
+   *		throw error if error?
+   *		console.log(device)
+   */
+
+  exports.getByUUID = function(uuid, callback) {
+    var username;
+    if (uuid == null) {
+      throw new errors.ResinMissingParameter('uuid');
+    }
+    if (!_.isString(name)) {
+      throw new errors.ResinInvalidParameter('uuid', name, 'not a string');
+    }
+    if (callback == null) {
+      throw new errors.ResinMissingParameter('callback');
+    }
+    if (!_.isFunction(callback)) {
+      throw new errors.ResinInvalidParameter('callback', callback, 'not a function');
+    }
+    username = token.getUsername();
+    if (username == null) {
+      return callback(new errors.ResinNotLoggedIn());
+    }
+    return pine.get({
+      resource: 'device',
+      options: {
+        expand: 'application',
+        filter: {
+          uuid: uuid,
+          user: {
+            username: username
+          }
+        }
+      }
+    }).then(function(device) {
+      if (_.isEmpty(device)) {
+        throw new errors.ResinDeviceNotFound(uuid);
+      }
+      device = _.first(device);
+      device.application_name = device.application[0].app_name;
+      return device;
+    }).nodeify(callback);
+  };
+
+
+  /**
    * has callback
    * @callback module:resin.models.device~hasCallback
    * @param {(Error|null)} error - error

--- a/build/models/device.js
+++ b/build/models/device.js
@@ -205,12 +205,20 @@
 
 
   /**
+   * getByUUID callback
+   * @callback module:resin.models.device~getByUUIDCallback
+   * @param {(Error|null)} error - error
+   * @param {Device} device - device
+   */
+
+
+  /**
    * @summary Get a single device by UUID
    * @public
    * @function
    *
    * @param {String} uuid - device UUID
-   * @param {module:resin.models.device~getCallback} callback - callback
+   * @param {module:resin.models.device~getByUUIDCallback} callback - callback
    *
    * @example
    *	resin.models.device.get '7cf02a62a3a84440b1bb5579a3d57469148943278630b17e7fc6c4f7b465c9', (error, device) ->

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -183,6 +183,58 @@ exports.get = (name, callback) ->
 	.nodeify(callback)
 
 ###*
+# @summary Get a single device by UUID
+# @public
+# @function
+#
+# @param {String} uuid - device UUID
+# @param {module:resin.models.device~getCallback} callback - callback
+#
+# @example
+#	resin.models.device.get '7cf02a62a3a84440b1bb5579a3d57469148943278630b17e7fc6c4f7b465c9', (error, device) ->
+#		throw error if error?
+#		console.log(device)
+###
+exports.getByUUID = (uuid, callback) ->
+
+	if not uuid?
+		throw new errors.ResinMissingParameter('uuid')
+
+	if not _.isString(name)
+		throw new errors.ResinInvalidParameter('uuid', name, 'not a string')
+
+	if not callback?
+		throw new errors.ResinMissingParameter('callback')
+
+	if not _.isFunction(callback)
+		throw new errors.ResinInvalidParameter('callback', callback, 'not a function')
+
+	username = token.getUsername()
+
+	if not username?
+		return callback(new errors.ResinNotLoggedIn())
+
+	return pine.get
+		resource: 'device'
+		options:
+			expand: 'application'
+			filter:
+				uuid: uuid
+				user: { username }
+
+	.then (device) ->
+		if _.isEmpty(device)
+			throw new errors.ResinDeviceNotFound(uuid)
+
+		device = _.first(device)
+
+		# TODO: Move to server
+		device.application_name = device.application[0].app_name
+
+		return device
+	.nodeify(callback)
+
+###*
 # has callback
 # @callback module:resin.models.device~hasCallback
 # @param {(Error|null)} error - error

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -183,12 +183,19 @@ exports.get = (name, callback) ->
 	.nodeify(callback)
 
 ###*
+# getByUUID callback
+# @callback module:resin.models.device~getByUUIDCallback
+# @param {(Error|null)} error - error
+# @param {Device} device - device
+###
+
+###*
 # @summary Get a single device by UUID
 # @public
 # @function
 #
 # @param {String} uuid - device UUID
-# @param {module:resin.models.device~getCallback} callback - callback
+# @param {module:resin.models.device~getByUUIDCallback} callback - callback
 #
 # @example
 #	resin.models.device.get '7cf02a62a3a84440b1bb5579a3d57469148943278630b17e7fc6c4f7b465c9', (error, device) ->

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -200,8 +200,8 @@ exports.getByUUID = (uuid, callback) ->
 	if not uuid?
 		throw new errors.ResinMissingParameter('uuid')
 
-	if not _.isString(name)
-		throw new errors.ResinInvalidParameter('uuid', name, 'not a string')
+	if not _.isString(uuid)
+		throw new errors.ResinInvalidParameter('uuid', uuid, 'not a string')
 
 	if not callback?
 		throw new errors.ResinMissingParameter('callback')


### PR DESCRIPTION
This PR adds a method to get a device by specifying UUID instead of name. Especially useful for apps that rely on the fact that devices know the UUID via env vars.
Not sure if the camelCasing is correct (getByUUID or getByUuid?).