### PR TITLE
Move device register from resin-device-register to the sdk

### DIFF
--- a/build/models/application.js
+++ b/build/models/application.js
@@ -411,7 +411,7 @@
     if (options == null) {
       options = {};
     }
-    return Promise.all([exports.gek(name), exports.getApiKey(name), auth.getUserId(), auth.whoami()]).spread(function(application, apiKey, userId, username) {
+    return Promise.all([exports.get(name), exports.getApiKey(name), auth.getUserId(), auth.whoami()]).spread(function(application, apiKey, userId, username) {
       if (username == null) {
         throw new errors.ResinNotLoggedIn();
       }

--- a/build/models/device.js
+++ b/build/models/device.js
@@ -4,9 +4,11 @@
  */
 
 (function() {
-  var Promise, _, configModel, errors, pine, request, token;
+  var Promise, _, configModel, crypto, errors, pine, request, token;
 
   Promise = require('bluebird');
+
+  crypto = require('crypto');
 
   _ = require('lodash-contrib');
 
@@ -631,6 +633,22 @@
       }
       return deviceManifest;
     }).nodeify(callback);
+  };
+
+
+  /**
+   * @summary Generate a random device UUID
+   * @function
+   * @public
+   *
+   * @returns {String} A generated UUID
+   *
+   * @example
+   * uuid = resin.models.device.generateUUID()
+   */
+
+  exports.generateUUID = function() {
+    return crypto.pseudoRandomBytes(31).toString('hex');
   };
 
 }).call(this);

--- a/build/models/device.js
+++ b/build/models/device.js
@@ -4,7 +4,7 @@
  */
 
 (function() {
-  var Promise, _, configModel, crypto, errors, pine, request, token;
+  var Promise, _, applicationModel, configModel, crypto, errors, pine, request, token;
 
   Promise = require('bluebird');
 
@@ -21,6 +21,8 @@
   token = require('resin-token');
 
   configModel = require('./config');
+
+  applicationModel = require('./application');
 
 
   /**
@@ -456,6 +458,47 @@
             }
           }
         });
+      });
+    }).nodeify(callback);
+  };
+
+
+  /**
+   * @summary Register a device with Resin.io
+   * @function
+   * @public
+   *
+   * @param {String} applicationName - application name
+   * @param {Object} [options={}] - options
+   * @param {String} [options.wifiSsid] - wifi ssid
+   * @param {String} [options.wifiKey] - wifi key
+   * @param {Function} callback - callback (error, device)
+   *
+   * @example
+   * resin.models.device.register 'MyApp',
+   *		wifiSsid: 'foobar'
+   *		wifiKey: 'hello'
+   *	, (error, device) ->
+   *		throw error if error?
+   *		console.log(device)
+   */
+
+  exports.register = function(applicationName, options, callback) {
+    if (options == null) {
+      options = {};
+    }
+    return applicationModel.getConfiguration(applicationName, options).then(function(config) {
+      return pine.post({
+        resource: 'device',
+        body: {
+          user: config.userId,
+          application: config.applicationId,
+          uuid: exports.generateUUID(),
+          device_type: config.deviceType
+        },
+        customOptions: {
+          apikey: config.apiKey
+        }
       });
     }).nodeify(callback);
   };

--- a/lib/models/application.coffee
+++ b/lib/models/application.coffee
@@ -335,7 +335,7 @@ exports.getApiKey = (name, callback) ->
 ###
 exports.getConfiguration = (name, options = {}, callback) ->
 	Promise.all([
-		exports.gek(name)
+		exports.get(name)
 		exports.getApiKey(name)
 		auth.getUserId()
 		auth.whoami()

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -3,6 +3,7 @@
 ###
 
 Promise = require('bluebird')
+crypto = require('crypto')
 _ = require('lodash-contrib')
 pine = require('resin-pine')
 errors = require('resin-errors')
@@ -507,3 +508,23 @@ exports.getManifestBySlug = (slug, callback) ->
 
 		return deviceManifest
 	.nodeify(callback)
+
+###*
+# @summary Generate a random device UUID
+# @function
+# @public
+#
+# @returns {String} A generated UUID
+#
+# @example
+# uuid = resin.models.device.generateUUID()
+###
+exports.generateUUID = ->
+
+	# I'd be nice if the UUID matched the output of a SHA-256 function,
+	# but although the length limit of the CN attribute in a X.509
+	# certificate is 64 chars, a 32 byte UUID (64 chars in hex) doesn't
+	# pass the certificate validation in OpenVPN This either means that
+	# the RFC counts a final NULL byte as part of the CN or that the
+	# OpenVPN/OpenSSL implementation has a bug.
+	return crypto.pseudoRandomBytes(31).toString('hex')

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -10,6 +10,7 @@ errors = require('resin-errors')
 request = Promise.promisifyAll(require('resin-request'))
 token = require('resin-token')
 configModel = require('./config')
+applicationModel = require('./application')
 
 ###*
 # A Resin API device
@@ -362,6 +363,40 @@ exports.note = (name, note, callback) ->
 						name: name
 						user: { username }
 
+	.nodeify(callback)
+
+###*
+# @summary Register a device with Resin.io
+# @function
+# @public
+#
+# @param {String} applicationName - application name
+# @param {Object} [options={}] - options
+# @param {String} [options.wifiSsid] - wifi ssid
+# @param {String} [options.wifiKey] - wifi key
+# @param {Function} callback - callback (error, device)
+#
+# @example
+# resin.models.device.register 'MyApp',
+#		wifiSsid: 'foobar'
+#		wifiKey: 'hello'
+#	, (error, device) ->
+#		throw error if error?
+#		console.log(device)
+###
+exports.register = (applicationName, options = {}, callback) ->
+	return applicationModel.getConfiguration(applicationName, options).then (config) ->
+		return pine.post
+			resource: 'device'
+			body:
+				user: config.userId
+				application: config.applicationId
+				uuid: exports.generateUUID()
+				device_type: config.deviceType
+			customOptions:
+				apikey: config.apiKey
+
+	# Allow promise based and callback based styles
 	.nodeify(callback)
 
 ###*

--- a/tests/models/device.spec.coffee
+++ b/tests/models/device.spec.coffee
@@ -590,3 +590,22 @@ describe 'Device Model:', ->
 						name: 'Raspberry Pi'
 						slug: 'raspberry-pi'
 					done()
+
+	describe '.generateUUID()', ->
+
+		it 'should return a string', ->
+			uuid = device.generateUUID()
+			expect(uuid).to.be.a('string')
+
+		it 'should have a length of 62 (31 bytes)', ->
+			uuid = device.generateUUID()
+			expect(uuid).to.have.length(62)
+
+		it 'should generate different uuids each time', ->
+			uuid1 = device.generateUUID()
+			uuid2 = device.generateUUID()
+			uuid3 = device.generateUUID()
+
+			expect(uuid1).to.not.equal(uuid2)
+			expect(uuid2).to.not.equal(uuid3)
+			expect(uuid3).to.not.equal(uuid1)


### PR DESCRIPTION
It was unnecessary to have this functionality as a separate module, when a simpler interface could be exposed by the SDK.