### PR TITLE
Fix device models examples

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -369,12 +369,12 @@ resin.models.application.getApiKey 'MyApp', (error, apiKey) ->
 **Access:** public  
 **Example**  
 ```js
-resin.models.devices.getAll().then (devices) ->
+resin.models.device.getAll().then (devices) ->
 	console.log(devices)
 ```
 **Example**  
 ```js
-resin.models.devices.getAll (error, devices) ->
+resin.models.device.getAll (error, devices) ->
 	throw error if error?
 	console.log(devices)
 ```
@@ -391,12 +391,12 @@ resin.models.devices.getAll (error, devices) ->
 
 **Example**  
 ```js
-resin.models.devices.getAllByApplication('MyApp').then (devices) ->
+resin.models.device.getAllByApplication('MyApp').then (devices) ->
 	console.log(devices)
 ```
 **Example**  
 ```js
-resin.models.devices.getAllByApplication 'MyApp', (error, devices) ->
+resin.models.device.getAllByApplication 'MyApp', (error, devices) ->
 	throw error if error?
 	console.log(devices)
 ```

--- a/build/models/device.js
+++ b/build/models/device.js
@@ -53,11 +53,11 @@ THE SOFTWARE.
    * @returns {Promise<Object[]>} devices
    *
    * @example
-   * resin.models.devices.getAll().then (devices) ->
+   * resin.models.device.getAll().then (devices) ->
    * 	console.log(devices)
    *
    * @example
-   * resin.models.devices.getAll (error, devices) ->
+   * resin.models.device.getAll (error, devices) ->
    * 	throw error if error?
    * 	console.log(devices)
    */
@@ -87,11 +87,11 @@ THE SOFTWARE.
    * @returns {Promise<Object[]>} devices
    *
    * @example
-   * resin.models.devices.getAllByApplication('MyApp').then (devices) ->
+   * resin.models.device.getAllByApplication('MyApp').then (devices) ->
    * 	console.log(devices)
    *
    * @example
-   * resin.models.devices.getAllByApplication 'MyApp', (error, devices) ->
+   * resin.models.device.getAllByApplication 'MyApp', (error, devices) ->
    * 	throw error if error?
    * 	console.log(devices)
    */

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -41,11 +41,11 @@ applicationModel = require('./application')
 # @returns {Promise<Object[]>} devices
 #
 # @example
-# resin.models.devices.getAll().then (devices) ->
+# resin.models.device.getAll().then (devices) ->
 # 	console.log(devices)
 #
 # @example
-# resin.models.devices.getAll (error, devices) ->
+# resin.models.device.getAll (error, devices) ->
 # 	throw error if error?
 # 	console.log(devices)
 ###
@@ -72,11 +72,11 @@ exports.getAll = (callback) ->
 # @returns {Promise<Object[]>} devices
 #
 # @example
-# resin.models.devices.getAllByApplication('MyApp').then (devices) ->
+# resin.models.device.getAllByApplication('MyApp').then (devices) ->
 # 	console.log(devices)
 #
 # @example
-# resin.models.devices.getAllByApplication 'MyApp', (error, devices) ->
+# resin.models.device.getAllByApplication 'MyApp', (error, devices) ->
 # 	throw error if error?
 # 	console.log(devices)
 ###


### PR DESCRIPTION
Some examples were using resin.models.devices instead of resin.models.device.