### PR TITLE
Upgrade Resin Request to v2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "resin-device-logs": "^1.0.0",
     "resin-errors": "^1.0.2",
     "resin-network-config": "^1.0.0",
-    "resin-request": "^2.1.0",
+    "resin-request": "^2.2.1",
     "resin-token": "^2.3.0",
     "resin-pine": "^1.3.0",
     "resin-settings-client": "^1.4.0"

--- a/tests/models/application.spec.coffee
+++ b/tests/models/application.spec.coffee
@@ -9,321 +9,332 @@ settings = require('../../lib/settings')
 application = require('../../lib/models/application')
 device = require('../../lib/models/device')
 auth = require('../../lib/auth')
+johnDoeFixture = require('../tokens.json').johndoe
 
 describe 'Application Model:', ->
 
-	describe '.getAll()', ->
+	describe 'given a /whoami endpoint', ->
 
-		describe 'given no applications', ->
+		beforeEach (done) ->
+			settings.get('remoteUrl').then (remoteUrl) ->
+				nock(remoteUrl).get('/whoami').reply(200, johnDoeFixture.token)
+				done()
 
-			beforeEach ->
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve([]))
+		afterEach ->
+			nock.cleanAll()
 
-			afterEach ->
-				@pineGetStub.restore()
+		describe '.getAll()', ->
 
-			it 'should eventually become an empty array', ->
-				promise = application.getAll()
-				m.chai.expect(promise).to.eventually.become([])
-
-		describe 'given applications', ->
-
-			describe 'given an application with devices', ->
+			describe 'given no applications', ->
 
 				beforeEach ->
 					@pineGetStub = m.sinon.stub(pine, 'get')
-					@pineGetStub.returns Promise.resolve [
-						{
-							name: 'MyApp'
-							id: 999
-							device: [
-								{ is_online: false }
-								{ is_online: true }
-							]
-						}
-					]
+					@pineGetStub.returns(Promise.resolve([]))
 
 				afterEach ->
 					@pineGetStub.restore()
 
-				it 'should eventually have the correct number of applications', ->
+				it 'should eventually become an empty array', ->
 					promise = application.getAll()
-					m.chai.expect(promise).to.eventually.have.length(1)
-
-				it 'should add online_devices', ->
-					promise = application.getAll().get(0)
-					m.chai.expect(promise.get('online_devices')).to.eventually.equal(1)
-
-				it 'should add devices_length', ->
-					promise = application.getAll().get(0)
-					m.chai.expect(promise.get('devices_length')).to.eventually.equal(2)
-
-	describe '.get()', ->
-
-		describe 'given no application', ->
-
-			beforeEach ->
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve([]))
-
-			afterEach ->
-				@pineGetStub.restore()
-
-			it 'should be rejected', ->
-				promise = application.get('MyApp')
-				m.chai.expect(promise).to.be.rejectedWith(errors.ResinApplicationNotFound)
-
-		describe 'given an application', ->
-
-			beforeEach ->
-				@application =
-					id: 999
-					device_type: 'raspberry-pi'
-
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve([ @application ]))
-
-			afterEach ->
-				@pineGetStub.restore()
-
-			it 'should eventually become the application', ->
-				promise = application.get('MyApp')
-				m.chai.expect(promise).to.eventually.become(@application)
-
-	describe '.has()', ->
-
-		describe 'given no application', ->
-
-			beforeEach ->
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve([]))
-
-			afterEach ->
-				@pineGetStub.restore()
-
-			it 'should eventually be false', ->
-				promise = application.has('MyApp')
-				m.chai.expect(promise).to.eventually.be.false
-
-		describe 'given an application', ->
-
-			beforeEach ->
-				applicationMock =
-					id: 999
-					app_name: 'App1'
-					device_type: 'raspberry-pi'
-
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve([ applicationMock ]))
-
-			afterEach ->
-				@pineGetStub.restore()
-
-			it 'should eventually be true', ->
-				promise = application.has('MyApp')
-				m.chai.expect(promise).to.eventually.be.true
-
-	describe '.hasAny()', ->
-
-		describe 'given no application', ->
-
-			beforeEach ->
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve([]))
-
-			afterEach ->
-				@pineGetStub.restore()
-
-			it 'should eventually be false', ->
-				promise = application.hasAny()
-				m.chai.expect(promise).to.eventually.be.false
-
-		describe 'given an application', ->
-
-			beforeEach ->
-				applicationMock =
-					id: 999
-					app_name: 'App1'
-					device_type: 'raspberry-pi'
-
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve([ applicationMock ]))
-
-			afterEach ->
-				@pineGetStub.restore()
-
-			it 'should eventually be true', ->
-				promise = application.hasAny()
-				m.chai.expect(promise).to.eventually.be.true
-
-	describe '.getById()', ->
-
-		describe 'given no application', ->
-
-			beforeEach ->
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve(undefined))
-
-			afterEach ->
-				@pineGetStub.restore()
-
-			it 'should be rejected', ->
-				promise = application.getById(9999)
-				m.chai.expect(promise).to.be.rejectedWith(errors.ResinApplicationNotFound)
-
-		describe 'given an application', ->
-
-			beforeEach ->
-				@application =
-					id: 999
-					app_name: 'App1'
-					device_type: 'raspberry-pi'
-
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve(@application))
-
-			afterEach ->
-				@pineGetStub.restore()
-
-			it 'should eventually become application', ->
-				promise = application.getById(999)
-				m.chai.expect(promise).to.eventually.become(@application)
-
-	describe '.create()', ->
-
-		describe 'given device slug was not found', ->
-
-			beforeEach ->
-				@deviceGetDeviceSlugStub = m.sinon.stub(device, 'getDeviceSlug')
-				@deviceGetDeviceSlugStub.returns(Promise.resolve(undefined))
-
-			afterEach ->
-				@deviceGetDeviceSlugStub.restore()
-
-			it 'should be rejected', ->
-				promise = application.create('MyApp', 'Unknown Device')
-				m.chai.expect(promise).to.be.rejectedWith(errors.ResinInvalidDeviceType)
-
-		describe 'given device slug was found', ->
-
-			beforeEach ->
-				@deviceGetDeviceSlugStub = m.sinon.stub(device, 'getDeviceSlug')
-				@deviceGetDeviceSlugStub.returns(Promise.resolve('raspberry-pi'))
-
-				@application =
-					id: 999
-					app_name: 'App1'
-					device_type: 'raspberry-pi'
-
-				@pinePostStub = m.sinon.stub(pine, 'post')
-				@pinePostStub.returns(Promise.resolve(@application))
-
-			afterEach ->
-				@deviceGetDeviceSlugStub.restore()
-				@pinePostStub.restore()
-
-			it 'should eventually become the application', ->
-				promise = application.create('MyApp', 'Unknown Device')
-				m.chai.expect(promise).to.eventually.become(@application)
-
-	describe '.restart()', ->
-
-		describe 'given an invalid application', ->
-
-			beforeEach ->
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve([]))
-
-			afterEach ->
-				@pineGetStub.restore()
-
-			it 'should reject with not found error', ->
-				promise = application.restart('App1')
-				m.chai.expect(promise).to.be.rejectedWith(errors.ResinApplicationNotFound)
-
-		describe 'given a valid application', ->
-
-			beforeEach ->
-				@application =
-					id: 999
-					app_name: 'App1'
-					device_type: 'raspberry-pi'
-
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve([ @application ]))
-
-			afterEach ->
-				@pineGetStub.restore()
-
-			describe 'given a successful restart', ->
-
-				beforeEach (done) ->
-					settings.get('remoteUrl').then (remoteUrl) ->
-						nock(remoteUrl).post('/application/999/restart').reply(200)
-						done()
+					m.chai.expect(promise).to.eventually.become([])
+
+			describe 'given applications', ->
+
+				describe 'given an application with devices', ->
+
+					beforeEach ->
+						@pineGetStub = m.sinon.stub(pine, 'get')
+						@pineGetStub.returns Promise.resolve [
+							{
+								name: 'MyApp'
+								id: 999
+								device: [
+									{ is_online: false }
+									{ is_online: true }
+								]
+							}
+						]
+
+					afterEach ->
+						@pineGetStub.restore()
+
+					it 'should eventually have the correct number of applications', ->
+						promise = application.getAll()
+						m.chai.expect(promise).to.eventually.have.length(1)
+
+					it 'should add online_devices', ->
+						promise = application.getAll().get(0)
+						m.chai.expect(promise.get('online_devices')).to.eventually.equal(1)
+
+					it 'should add devices_length', ->
+						promise = application.getAll().get(0)
+						m.chai.expect(promise.get('devices_length')).to.eventually.equal(2)
+
+		describe '.get()', ->
+
+			describe 'given no application', ->
+
+				beforeEach ->
+					@pineGetStub = m.sinon.stub(pine, 'get')
+					@pineGetStub.returns(Promise.resolve([]))
 
 				afterEach ->
-					nock.cleanAll()
+					@pineGetStub.restore()
 
-				it 'should eventually be undefined', ->
-					promise = application.restart('App1')
-					m.chai.expect(promise).to.eventually.be.undefined
+				it 'should be rejected', ->
+					promise = application.get('MyApp')
+					m.chai.expect(promise).to.be.rejectedWith(errors.ResinApplicationNotFound)
+
+			describe 'given an application', ->
+
+				beforeEach ->
+					@application =
+						id: 999
+						device_type: 'raspberry-pi'
+
+					@pineGetStub = m.sinon.stub(pine, 'get')
+					@pineGetStub.returns(Promise.resolve([ @application ]))
+
+				afterEach ->
+					@pineGetStub.restore()
+
+				it 'should eventually become the application', ->
+					promise = application.get('MyApp')
+					m.chai.expect(promise).to.eventually.become(@application)
+
+		describe '.has()', ->
+
+			describe 'given no application', ->
+
+				beforeEach ->
+					@pineGetStub = m.sinon.stub(pine, 'get')
+					@pineGetStub.returns(Promise.resolve([]))
+
+				afterEach ->
+					@pineGetStub.restore()
+
+				it 'should eventually be false', ->
+					promise = application.has('MyApp')
+					m.chai.expect(promise).to.eventually.be.false
+
+			describe 'given an application', ->
+
+				beforeEach ->
+					applicationMock =
+						id: 999
+						app_name: 'App1'
+						device_type: 'raspberry-pi'
+
+					@pineGetStub = m.sinon.stub(pine, 'get')
+					@pineGetStub.returns(Promise.resolve([ applicationMock ]))
+
+				afterEach ->
+					@pineGetStub.restore()
+
+				it 'should eventually be true', ->
+					promise = application.has('MyApp')
+					m.chai.expect(promise).to.eventually.be.true
+
+		describe '.hasAny()', ->
+
+			describe 'given no application', ->
+
+				beforeEach ->
+					@pineGetStub = m.sinon.stub(pine, 'get')
+					@pineGetStub.returns(Promise.resolve([]))
+
+				afterEach ->
+					@pineGetStub.restore()
+
+				it 'should eventually be false', ->
+					promise = application.hasAny()
+					m.chai.expect(promise).to.eventually.be.false
+
+			describe 'given an application', ->
+
+				beforeEach ->
+					applicationMock =
+						id: 999
+						app_name: 'App1'
+						device_type: 'raspberry-pi'
+
+					@pineGetStub = m.sinon.stub(pine, 'get')
+					@pineGetStub.returns(Promise.resolve([ applicationMock ]))
+
+				afterEach ->
+					@pineGetStub.restore()
+
+				it 'should eventually be true', ->
+					promise = application.hasAny()
+					m.chai.expect(promise).to.eventually.be.true
+
+		describe '.getById()', ->
+
+			describe 'given no application', ->
+
+				beforeEach ->
+					@pineGetStub = m.sinon.stub(pine, 'get')
+					@pineGetStub.returns(Promise.resolve(undefined))
+
+				afterEach ->
+					@pineGetStub.restore()
+
+				it 'should be rejected', ->
+					promise = application.getById(9999)
+					m.chai.expect(promise).to.be.rejectedWith(errors.ResinApplicationNotFound)
+
+			describe 'given an application', ->
+
+				beforeEach ->
+					@application =
+						id: 999
+						app_name: 'App1'
+						device_type: 'raspberry-pi'
+
+					@pineGetStub = m.sinon.stub(pine, 'get')
+					@pineGetStub.returns(Promise.resolve(@application))
+
+				afterEach ->
+					@pineGetStub.restore()
+
+				it 'should eventually become application', ->
+					promise = application.getById(999)
+					m.chai.expect(promise).to.eventually.become(@application)
+
+		describe '.create()', ->
+
+			describe 'given device slug was not found', ->
+
+				beforeEach ->
+					@deviceGetDeviceSlugStub = m.sinon.stub(device, 'getDeviceSlug')
+					@deviceGetDeviceSlugStub.returns(Promise.resolve(undefined))
+
+				afterEach ->
+					@deviceGetDeviceSlugStub.restore()
+
+				it 'should be rejected', ->
+					promise = application.create('MyApp', 'Unknown Device')
+					m.chai.expect(promise).to.be.rejectedWith(errors.ResinInvalidDeviceType)
+
+			describe 'given device slug was found', ->
+
+				beforeEach ->
+					@deviceGetDeviceSlugStub = m.sinon.stub(device, 'getDeviceSlug')
+					@deviceGetDeviceSlugStub.returns(Promise.resolve('raspberry-pi'))
+
+					@application =
+						id: 999
+						app_name: 'App1'
+						device_type: 'raspberry-pi'
+
+					@pinePostStub = m.sinon.stub(pine, 'post')
+					@pinePostStub.returns(Promise.resolve(@application))
+
+				afterEach ->
+					@deviceGetDeviceSlugStub.restore()
+					@pinePostStub.restore()
+
+				it 'should eventually become the application', ->
+					promise = application.create('MyApp', 'Unknown Device')
+					m.chai.expect(promise).to.eventually.become(@application)
+
+		describe '.restart()', ->
 
 			describe 'given an invalid application', ->
 
-				beforeEach (done) ->
-					settings.get('remoteUrl').then (remoteUrl) ->
-						nock(remoteUrl).post('/application/999/restart')
-							.reply(403, 'You do not have permission to access this application')
-						done()
+				beforeEach ->
+					@pineGetStub = m.sinon.stub(pine, 'get')
+					@pineGetStub.returns(Promise.resolve([]))
 
 				afterEach ->
-					nock.cleanAll()
+					@pineGetStub.restore()
 
-				it 'should be rejected with an error message', ->
+				it 'should reject with not found error', ->
 					promise = application.restart('App1')
-					m.chai.expect(promise).to.be.rejectedWith('You do not have permission to access this application')
+					m.chai.expect(promise).to.be.rejectedWith(errors.ResinApplicationNotFound)
 
-	describe '.getApiKey()', ->
+			describe 'given a valid application', ->
 
-		describe 'given an invalid application', ->
+				beforeEach ->
+					@application =
+						id: 999
+						app_name: 'App1'
+						device_type: 'raspberry-pi'
 
-			beforeEach ->
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve([]))
-
-			afterEach ->
-				@pineGetStub.restore()
-
-			it 'should reject with not found error', ->
-				promise = application.getApiKey('App1')
-				m.chai.expect(promise).to.be.rejectedWith(errors.ResinApplicationNotFound)
-
-		describe 'given a valid application', ->
-
-			beforeEach ->
-				@application =
-					id: 999
-					app_name: 'App1'
-					device_type: 'raspberry-pi'
-
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve([ @application ]))
-
-			afterEach ->
-				@pineGetStub.restore()
-
-			describe 'given a successful request', ->
-
-				beforeEach (done) ->
-					settings.get('remoteUrl').then (remoteUrl) ->
-						nock(remoteUrl).post('/application/999/generate-api-key').reply(200, 'asdf1234')
-						done()
+					@pineGetStub = m.sinon.stub(pine, 'get')
+					@pineGetStub.returns(Promise.resolve([ @application ]))
 
 				afterEach ->
-					nock.cleanAll()
+					@pineGetStub.restore()
 
-				it 'should eventually be the api key', ->
+				describe 'given a successful restart', ->
+
+					beforeEach (done) ->
+						settings.get('remoteUrl').then (remoteUrl) ->
+							nock(remoteUrl).post('/application/999/restart').reply(200)
+							done()
+
+					afterEach ->
+						nock.cleanAll()
+
+					it 'should eventually be undefined', ->
+						promise = application.restart('App1')
+						m.chai.expect(promise).to.eventually.be.undefined
+
+				describe 'given an invalid application', ->
+
+					beforeEach (done) ->
+						settings.get('remoteUrl').then (remoteUrl) ->
+							nock(remoteUrl).post('/application/999/restart')
+								.reply(403, 'You do not have permission to access this application')
+							done()
+
+					afterEach ->
+						nock.cleanAll()
+
+					it 'should be rejected with an error message', ->
+						promise = application.restart('App1')
+						m.chai.expect(promise).to.be.rejectedWith('You do not have permission to access this application')
+
+		describe '.getApiKey()', ->
+
+			describe 'given an invalid application', ->
+
+				beforeEach ->
+					@pineGetStub = m.sinon.stub(pine, 'get')
+					@pineGetStub.returns(Promise.resolve([]))
+
+				afterEach ->
+					@pineGetStub.restore()
+
+				it 'should reject with not found error', ->
 					promise = application.getApiKey('App1')
-					m.chai.expect(promise).to.eventually.equal('asdf1234')
+					m.chai.expect(promise).to.be.rejectedWith(errors.ResinApplicationNotFound)
+
+			describe 'given a valid application', ->
+
+				beforeEach ->
+					@application =
+						id: 999
+						app_name: 'App1'
+						device_type: 'raspberry-pi'
+
+					@pineGetStub = m.sinon.stub(pine, 'get')
+					@pineGetStub.returns(Promise.resolve([ @application ]))
+
+				afterEach ->
+					@pineGetStub.restore()
+
+				describe 'given a successful request', ->
+
+					beforeEach (done) ->
+						settings.get('remoteUrl').then (remoteUrl) ->
+							nock(remoteUrl).post('/application/999/generate-api-key').reply(200, 'asdf1234')
+							done()
+
+					afterEach ->
+						nock.cleanAll()
+
+					it 'should eventually be the api key', ->
+						promise = application.getApiKey('App1')
+						m.chai.expect(promise).to.eventually.equal('asdf1234')

--- a/tests/models/device.spec.coffee
+++ b/tests/models/device.spec.coffee
@@ -8,635 +8,646 @@ settings = require('../../lib/settings')
 device = require('../../lib/models/device')
 application = require('../../lib/models/application')
 config = require('../../lib/models/config')
+johnDoeFixture = require('../tokens.json').johndoe
 
 describe 'Device Model:', ->
 
-	describe '.getAll()', ->
+	describe 'given a /whoami endpoint', ->
 
-		describe 'given no devices', ->
+		beforeEach (done) ->
+			settings.get('remoteUrl').then (remoteUrl) ->
+				nock(remoteUrl).get('/whoami').reply(200, johnDoeFixture.token)
+				done()
 
-			beforeEach ->
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve([]))
+		afterEach ->
+			nock.cleanAll()
 
-			afterEach ->
-				@pineGetStub.restore()
+		describe '.getAll()', ->
 
-			it 'should eventually become an empty array', ->
-				promise = device.getAll()
-				m.chai.expect(promise).to.eventually.become([])
+			describe 'given no devices', ->
 
-		describe 'given devices', ->
-
-			beforeEach ->
-				@devices = [
-					{
-						is_online: 0
-						id: 1
-						name: 'Device1'
-						application: [
-							{ app_name: 'MyApp' }
-						]
-					}
-					{
-						is_online: 0
-						id: 1
-						name: 'Device1'
-						application: [
-							{ app_name: 'MyApp' }
-						]
-					}
-				]
-
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve(@devices))
-
-			afterEach ->
-				@pineGetStub.restore()
-
-			it 'should eventually become the devices with an application_name property', ->
-				promise = device.getAll()
-				m.chai.expect(promise).to.eventually.become [
-					{
-						is_online: 0
-						id: 1
-						name: 'Device1'
-						application_name: 'MyApp'
-						application: [
-							{ app_name: 'MyApp' }
-						]
-					}
-					{
-						is_online: 0
-						id: 1
-						name: 'Device1'
-						application_name: 'MyApp'
-						application: [
-							{ app_name: 'MyApp' }
-						]
-					}
-				]
-
-	describe '.getAllByApplication()', ->
-
-		describe 'given no devices', ->
-
-			beforeEach ->
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve([]))
-
-			afterEach ->
-				@pineGetStub.restore()
-
-			it 'should eventually become an empty array', ->
-				promise = device.getAllByApplication('MyApp')
-				m.chai.expect(promise).to.eventually.become([])
-
-		describe 'given a device', ->
-
-			beforeEach ->
-				@device =
-					id: 1
-					name: 'Device1'
-					application: [
-						app_name: 'App1'
-					]
-
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve([ @device ]))
-
-			afterEach ->
-				@pineGetStub.restore()
-
-			it 'should eventually return the correct number of devices', ->
-				promise = device.getAllByApplication('MyApp')
-				m.chai.expect(promise).to.eventually.have.length(1)
-
-			it 'should add application_name', ->
-				promise = device.getAllByApplication('MyApp')
-				m.chai.expect(promise).to.eventually.become [
-					id: 1
-					name: 'Device1'
-					application_name: 'App1'
-					application: [
-						app_name: 'App1'
-					]
-				]
-
-	describe '.get()', ->
-
-		describe 'given no devices', ->
-
-			beforeEach ->
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve([]))
-
-			afterEach ->
-				@pineGetStub.restore()
-
-			it 'should be rejected', ->
-				promise = device.get('7cf02')
-				m.chai.expect(promise).to.be.rejectedWith(errors.ResinDeviceNotFound)
-
-		describe 'given a device', ->
-
-			beforeEach ->
-				@device =
-					id: 1
-					name: 'Device1'
-					uuid: '1234'
-					application: [
-						app_name: 'App1'
-					]
-
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve([ @device ]))
-
-			afterEach ->
-				@pineGetStub.restore()
-
-			it 'should eventually return the device', ->
-				promise = device.get('1234')
-				m.chai.expect(promise).to.eventually.become
-					id: 1
-					name: 'Device1'
-					uuid: '1234'
-					application_name: 'App1'
-					application: [
-						app_name: 'App1'
-					]
-
-	describe '.getByName()', ->
-
-		describe 'given no devices', ->
-
-			beforeEach ->
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve([]))
-
-			afterEach ->
-				@pineGetStub.restore()
-
-			it 'should be rejected', ->
-				promise = device.getByName('MyDevice')
-				m.chai.expect(promise).to.be.rejectedWith(errors.ResinDeviceNotFound)
-
-		describe 'given a device', ->
-
-			beforeEach ->
-				@device =
-					id: 1
-					name: 'Device1'
-					uuid: '1234'
-					application: [
-						app_name: 'App1'
-					]
-
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve([ @device ]))
-
-			afterEach ->
-				@pineGetStub.restore()
-
-			it 'should eventually return the device', ->
-				promise = device.getByName('Device1')
-				m.chai.expect(promise).to.eventually.become [
-					id: 1
-					name: 'Device1'
-					uuid: '1234'
-					application_name: 'App1'
-					application: [
-						app_name: 'App1'
-					]
-				]
-
-		describe 'given multiple devices with the same name', ->
-
-			beforeEach ->
-				@devices = [
-					{
-						id: 1
-						name: 'Device1'
-						uuid: '1234'
-						application: [
-							app_name: 'App1'
-						]
-					}
-					{
-						id: 2
-						name: 'Device1'
-						uuid: '5678'
-						application: [
-							app_name: 'App1'
-						]
-					}
-				]
-
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve(@devices))
-
-			afterEach ->
-				@pineGetStub.restore()
-
-			it 'should eventually return the devices', ->
-				promise = device.getByName('Device1')
-				m.chai.expect(promise).to.eventually.become [
-					{
-						id: 1
-						name: 'Device1'
-						uuid: '1234'
-						application_name: 'App1'
-						application: [
-							app_name: 'App1'
-						]
-					}
-					{
-						id: 2
-						name: 'Device1'
-						uuid: '5678'
-						application_name: 'App1'
-						application: [
-							app_name: 'App1'
-						]
-					}
-				]
-
-	describe '.getName()', ->
-
-		describe 'given no devices', ->
-
-			beforeEach ->
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve([]))
-
-			afterEach ->
-				@pineGetStub.restore()
-
-			it 'should be rejected', ->
-				promise = device.getName('1234')
-				m.chai.expect(promise).to.be.rejectedWith(errors.ResinDeviceNotFound)
-
-		describe 'given a device', ->
-
-			beforeEach ->
-				@device =
-					id: 1
-					name: 'Device1'
-					uuid: '1234'
-					application: [
-						app_name: 'App1'
-					]
-
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve([ @device ]))
-
-			afterEach ->
-				@pineGetStub.restore()
-
-			it 'should eventually return the device name', ->
-				promise = device.getName('1234')
-				m.chai.expect(promise).to.eventually.equal('Device1')
-
-	describe '.getApplicationName()', ->
-
-		describe 'given no devices', ->
-
-			beforeEach ->
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve([]))
-
-			afterEach ->
-				@pineGetStub.restore()
-
-			it 'should be rejected', ->
-				promise = device.getApplicationName('7cf02')
-				m.chai.expect(promise).to.be.rejectedWith(errors.ResinDeviceNotFound)
-
-		describe 'given a device', ->
-
-			beforeEach ->
-				@device =
-					id: 1
-					name: 'Device1'
-					uuid: '1234'
-					application: [
-						app_name: 'App1'
-					]
-
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve([ @device ]))
-
-			afterEach ->
-				@pineGetStub.restore()
-
-			it 'should eventually return the application name', ->
-				promise = device.getApplicationName('1234')
-				m.chai.expect(promise).to.eventually.equal('App1')
-
-	describe '.has()', ->
-
-		describe 'given no devices', ->
-
-			beforeEach ->
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve([]))
-
-			afterEach ->
-				@pineGetStub.restore()
-
-			it 'should eventually be false', ->
-				promise = device.has('1234')
-				m.chai.expect(promise).to.eventually.be.false
-
-		describe 'given the device', ->
-
-			beforeEach ->
-				@device =
-					id: 1
-					name: 'Device1'
-					uuid: '1234'
-					application: [
-						app_name: 'App1'
-					]
-
-				@pineGetStub = m.sinon.stub(pine, 'get')
-				@pineGetStub.returns(Promise.resolve([ @device ]))
-
-			afterEach ->
-				@pineGetStub.restore()
-
-			it 'should eventually be true', ->
-				promise = device.has('1234')
-				m.chai.expect(promise).to.eventually.be.true
-
-	describe '.isOnline()', ->
-
-		describe 'given the device does not exist', ->
-
-			beforeEach ->
-				@deviceGetStub = m.sinon.stub(device, 'get')
-				@deviceGetStub.returns(Promise.reject(new errors.ResinDeviceNotFound('1234')))
-
-			afterEach ->
-				@deviceGetStub.restore()
-
-			it 'should be rejected', ->
-				promise = device.isOnline('1234')
-				m.chai.expect(promise).to.be.rejectedWith(errors.ResinDeviceNotFound)
-
-		describe 'given the device is online', ->
-
-			beforeEach ->
-				@deviceGetStub = m.sinon.stub(device, 'get')
-				@deviceGetStub.returns(Promise.resolve(is_online: true))
-
-			afterEach ->
-				@deviceGetStub.restore()
-
-			it 'should eventually be true', ->
-				promise = device.isOnline('1234')
-				m.chai.expect(promise).to.eventually.be.true
-
-		describe 'given the device is not online', ->
-
-			beforeEach ->
-				@deviceGetStub = m.sinon.stub(device, 'get')
-				@deviceGetStub.returns(Promise.resolve(is_online: false))
-
-			afterEach ->
-				@deviceGetStub.restore()
-
-			it 'should eventually be false', ->
-				promise = device.isOnline('1234')
-				m.chai.expect(promise).to.eventually.be.false
-
-	describe '.getLocalIPAddresses()', ->
-
-		describe 'given the device is online', ->
-
-			beforeEach ->
-				@deviceGetStub = m.sinon.stub(device, 'get')
-				@deviceGetStub.returns Promise.resolve
-					is_online: true
-					ip_address: '10.2.0.78 192.168.2.7'
-					vpn_address: '10.2.0.78'
-
-			afterEach ->
-				@deviceGetStub.restore()
-
-			it 'should eventually be the an array with the local ip address', ->
-				promise = device.getLocalIPAddresses('1234')
-				m.chai.expect(promise).to.eventually.become([ '192.168.2.7' ])
-
-		describe 'given the device is not online', ->
-
-			beforeEach ->
-				@deviceGetStub = m.sinon.stub(device, 'get')
-				@deviceGetStub.returns Promise.resolve
-					is_online: false
-					ip_address: '10.2.0.78 192.168.2.7'
-					vpn_address: '10.2.0.78'
-
-			afterEach ->
-				@deviceGetStub.restore()
-
-			it 'should be rejected with an error message', ->
-				promise = device.getLocalIPAddresses('1234')
-				m.chai.expect(promise).to.be.rejectedWith('The device is offline: 1234')
-
-		describe 'given the device is online, but no local ip exist', ->
-
-			beforeEach ->
-				@deviceGetStub = m.sinon.stub(device, 'get')
-				@deviceGetStub.returns Promise.resolve
-					is_online: true
-					ip_address: '10.2.0.78'
-					vpn_address: '10.2.0.78'
-
-			afterEach ->
-				@deviceGetStub.restore()
-
-			it 'should eventually become an empty array', ->
-				promise = device.getLocalIPAddresses('1234')
-				m.chai.expect(promise).to.eventually.become([])
-
-		describe 'given the device is online and has multiple local ip addresses', ->
-
-			beforeEach ->
-				@deviceGetStub = m.sinon.stub(device, 'get')
-				@deviceGetStub.returns Promise.resolve
-					is_online: true
-					ip_address: '10.2.0.78 192.168.2.7 192.168.2.10'
-					vpn_address: '10.2.0.78'
-
-			afterEach ->
-				@deviceGetStub.restore()
-
-			it 'should eventually be the an array with the local ip addresses', ->
-				promise = device.getLocalIPAddresses('1234')
-				m.chai.expect(promise).to.eventually.become([ '192.168.2.7', '192.168.2.10' ])
-
-	describe '.identify()', ->
-
-		describe 'given the device does not exist', ->
-
-			beforeEach ->
-				@deviceHasStub = m.sinon.stub(device, 'has')
-				@deviceHasStub.returns(Promise.resolve(false))
-
-			afterEach ->
-				@deviceHasStub.restore()
-
-			it 'should be rejected', ->
-				promise = device.identify('1234')
-				m.chai.expect(promise).to.be.rejectedWith(errors.ResinDeviceNotFound)
-
-		describe 'given the device exists', ->
-
-			beforeEach ->
-				@deviceHasStub = m.sinon.stub(device, 'has')
-				@deviceHasStub.returns(Promise.resolve(true))
-
-			afterEach ->
-				@deviceHasStub.restore()
-
-			describe 'given the device is offline', ->
-
-				beforeEach (done) ->
-					settings.get('remoteUrl').then (remoteUrl) ->
-						nock(remoteUrl).post('/blink').reply(404, 'No online device(s) found')
-						done()
+				beforeEach ->
+					@pineGetStub = m.sinon.stub(pine, 'get')
+					@pineGetStub.returns(Promise.resolve([]))
 
 				afterEach ->
-					nock.cleanAll()
+					@pineGetStub.restore()
 
-				it 'should be rejected with the correct error message', ->
-					promise = device.identify('1234')
-					m.chai.expect(promise).to.be.rejectedWith('No online device(s) found')
+				it 'should eventually become an empty array', ->
+					promise = device.getAll()
+					m.chai.expect(promise).to.eventually.become([])
+
+			describe 'given devices', ->
+
+				beforeEach ->
+					@devices = [
+						{
+							is_online: 0
+							id: 1
+							name: 'Device1'
+							application: [
+								{ app_name: 'MyApp' }
+							]
+						}
+						{
+							is_online: 0
+							id: 1
+							name: 'Device1'
+							application: [
+								{ app_name: 'MyApp' }
+							]
+						}
+					]
+
+					@pineGetStub = m.sinon.stub(pine, 'get')
+					@pineGetStub.returns(Promise.resolve(@devices))
+
+				afterEach ->
+					@pineGetStub.restore()
+
+				it 'should eventually become the devices with an application_name property', ->
+					promise = device.getAll()
+					m.chai.expect(promise).to.eventually.become [
+						{
+							is_online: 0
+							id: 1
+							name: 'Device1'
+							application_name: 'MyApp'
+							application: [
+								{ app_name: 'MyApp' }
+							]
+						}
+						{
+							is_online: 0
+							id: 1
+							name: 'Device1'
+							application_name: 'MyApp'
+							application: [
+								{ app_name: 'MyApp' }
+							]
+						}
+					]
+
+		describe '.getAllByApplication()', ->
+
+			describe 'given no devices', ->
+
+				beforeEach ->
+					@pineGetStub = m.sinon.stub(pine, 'get')
+					@pineGetStub.returns(Promise.resolve([]))
+
+				afterEach ->
+					@pineGetStub.restore()
+
+				it 'should eventually become an empty array', ->
+					promise = device.getAllByApplication('MyApp')
+					m.chai.expect(promise).to.eventually.become([])
+
+			describe 'given a device', ->
+
+				beforeEach ->
+					@device =
+						id: 1
+						name: 'Device1'
+						application: [
+							app_name: 'App1'
+						]
+
+					@pineGetStub = m.sinon.stub(pine, 'get')
+					@pineGetStub.returns(Promise.resolve([ @device ]))
+
+				afterEach ->
+					@pineGetStub.restore()
+
+				it 'should eventually return the correct number of devices', ->
+					promise = device.getAllByApplication('MyApp')
+					m.chai.expect(promise).to.eventually.have.length(1)
+
+				it 'should add application_name', ->
+					promise = device.getAllByApplication('MyApp')
+					m.chai.expect(promise).to.eventually.become [
+						id: 1
+						name: 'Device1'
+						application_name: 'App1'
+						application: [
+							app_name: 'App1'
+						]
+					]
+
+		describe '.get()', ->
+
+			describe 'given no devices', ->
+
+				beforeEach ->
+					@pineGetStub = m.sinon.stub(pine, 'get')
+					@pineGetStub.returns(Promise.resolve([]))
+
+				afterEach ->
+					@pineGetStub.restore()
+
+				it 'should be rejected', ->
+					promise = device.get('7cf02')
+					m.chai.expect(promise).to.be.rejectedWith(errors.ResinDeviceNotFound)
+
+			describe 'given a device', ->
+
+				beforeEach ->
+					@device =
+						id: 1
+						name: 'Device1'
+						uuid: '1234'
+						application: [
+							app_name: 'App1'
+						]
+
+					@pineGetStub = m.sinon.stub(pine, 'get')
+					@pineGetStub.returns(Promise.resolve([ @device ]))
+
+				afterEach ->
+					@pineGetStub.restore()
+
+				it 'should eventually return the device', ->
+					promise = device.get('1234')
+					m.chai.expect(promise).to.eventually.become
+						id: 1
+						name: 'Device1'
+						uuid: '1234'
+						application_name: 'App1'
+						application: [
+							app_name: 'App1'
+						]
+
+		describe '.getByName()', ->
+
+			describe 'given no devices', ->
+
+				beforeEach ->
+					@pineGetStub = m.sinon.stub(pine, 'get')
+					@pineGetStub.returns(Promise.resolve([]))
+
+				afterEach ->
+					@pineGetStub.restore()
+
+				it 'should be rejected', ->
+					promise = device.getByName('MyDevice')
+					m.chai.expect(promise).to.be.rejectedWith(errors.ResinDeviceNotFound)
+
+			describe 'given a device', ->
+
+				beforeEach ->
+					@device =
+						id: 1
+						name: 'Device1'
+						uuid: '1234'
+						application: [
+							app_name: 'App1'
+						]
+
+					@pineGetStub = m.sinon.stub(pine, 'get')
+					@pineGetStub.returns(Promise.resolve([ @device ]))
+
+				afterEach ->
+					@pineGetStub.restore()
+
+				it 'should eventually return the device', ->
+					promise = device.getByName('Device1')
+					m.chai.expect(promise).to.eventually.become [
+						id: 1
+						name: 'Device1'
+						uuid: '1234'
+						application_name: 'App1'
+						application: [
+							app_name: 'App1'
+						]
+					]
+
+			describe 'given multiple devices with the same name', ->
+
+				beforeEach ->
+					@devices = [
+						{
+							id: 1
+							name: 'Device1'
+							uuid: '1234'
+							application: [
+								app_name: 'App1'
+							]
+						}
+						{
+							id: 2
+							name: 'Device1'
+							uuid: '5678'
+							application: [
+								app_name: 'App1'
+							]
+						}
+					]
+
+					@pineGetStub = m.sinon.stub(pine, 'get')
+					@pineGetStub.returns(Promise.resolve(@devices))
+
+				afterEach ->
+					@pineGetStub.restore()
+
+				it 'should eventually return the devices', ->
+					promise = device.getByName('Device1')
+					m.chai.expect(promise).to.eventually.become [
+						{
+							id: 1
+							name: 'Device1'
+							uuid: '1234'
+							application_name: 'App1'
+							application: [
+								app_name: 'App1'
+							]
+						}
+						{
+							id: 2
+							name: 'Device1'
+							uuid: '5678'
+							application_name: 'App1'
+							application: [
+								app_name: 'App1'
+							]
+						}
+					]
+
+		describe '.getName()', ->
+
+			describe 'given no devices', ->
+
+				beforeEach ->
+					@pineGetStub = m.sinon.stub(pine, 'get')
+					@pineGetStub.returns(Promise.resolve([]))
+
+				afterEach ->
+					@pineGetStub.restore()
+
+				it 'should be rejected', ->
+					promise = device.getName('1234')
+					m.chai.expect(promise).to.be.rejectedWith(errors.ResinDeviceNotFound)
+
+			describe 'given a device', ->
+
+				beforeEach ->
+					@device =
+						id: 1
+						name: 'Device1'
+						uuid: '1234'
+						application: [
+							app_name: 'App1'
+						]
+
+					@pineGetStub = m.sinon.stub(pine, 'get')
+					@pineGetStub.returns(Promise.resolve([ @device ]))
+
+				afterEach ->
+					@pineGetStub.restore()
+
+				it 'should eventually return the device name', ->
+					promise = device.getName('1234')
+					m.chai.expect(promise).to.eventually.equal('Device1')
+
+		describe '.getApplicationName()', ->
+
+			describe 'given no devices', ->
+
+				beforeEach ->
+					@pineGetStub = m.sinon.stub(pine, 'get')
+					@pineGetStub.returns(Promise.resolve([]))
+
+				afterEach ->
+					@pineGetStub.restore()
+
+				it 'should be rejected', ->
+					promise = device.getApplicationName('7cf02')
+					m.chai.expect(promise).to.be.rejectedWith(errors.ResinDeviceNotFound)
+
+			describe 'given a device', ->
+
+				beforeEach ->
+					@device =
+						id: 1
+						name: 'Device1'
+						uuid: '1234'
+						application: [
+							app_name: 'App1'
+						]
+
+					@pineGetStub = m.sinon.stub(pine, 'get')
+					@pineGetStub.returns(Promise.resolve([ @device ]))
+
+				afterEach ->
+					@pineGetStub.restore()
+
+				it 'should eventually return the application name', ->
+					promise = device.getApplicationName('1234')
+					m.chai.expect(promise).to.eventually.equal('App1')
+
+		describe '.has()', ->
+
+			describe 'given no devices', ->
+
+				beforeEach ->
+					@pineGetStub = m.sinon.stub(pine, 'get')
+					@pineGetStub.returns(Promise.resolve([]))
+
+				afterEach ->
+					@pineGetStub.restore()
+
+				it 'should eventually be false', ->
+					promise = device.has('1234')
+					m.chai.expect(promise).to.eventually.be.false
+
+			describe 'given the device', ->
+
+				beforeEach ->
+					@device =
+						id: 1
+						name: 'Device1'
+						uuid: '1234'
+						application: [
+							app_name: 'App1'
+						]
+
+					@pineGetStub = m.sinon.stub(pine, 'get')
+					@pineGetStub.returns(Promise.resolve([ @device ]))
+
+				afterEach ->
+					@pineGetStub.restore()
+
+				it 'should eventually be true', ->
+					promise = device.has('1234')
+					m.chai.expect(promise).to.eventually.be.true
+
+		describe '.isOnline()', ->
+
+			describe 'given the device does not exist', ->
+
+				beforeEach ->
+					@deviceGetStub = m.sinon.stub(device, 'get')
+					@deviceGetStub.returns(Promise.reject(new errors.ResinDeviceNotFound('1234')))
+
+				afterEach ->
+					@deviceGetStub.restore()
+
+				it 'should be rejected', ->
+					promise = device.isOnline('1234')
+					m.chai.expect(promise).to.be.rejectedWith(errors.ResinDeviceNotFound)
 
 			describe 'given the device is online', ->
 
-				beforeEach (done) ->
-					settings.get('remoteUrl').then (remoteUrl) ->
-						nock(remoteUrl).post('/blink').reply(200)
-						done()
+				beforeEach ->
+					@deviceGetStub = m.sinon.stub(device, 'get')
+					@deviceGetStub.returns(Promise.resolve(is_online: true))
 
 				afterEach ->
-					nock.cleanAll()
+					@deviceGetStub.restore()
 
-				it 'should eventually be undefined', ->
+				it 'should eventually be true', ->
+					promise = device.isOnline('1234')
+					m.chai.expect(promise).to.eventually.be.true
+
+			describe 'given the device is not online', ->
+
+				beforeEach ->
+					@deviceGetStub = m.sinon.stub(device, 'get')
+					@deviceGetStub.returns(Promise.resolve(is_online: false))
+
+				afterEach ->
+					@deviceGetStub.restore()
+
+				it 'should eventually be false', ->
+					promise = device.isOnline('1234')
+					m.chai.expect(promise).to.eventually.be.false
+
+		describe '.getLocalIPAddresses()', ->
+
+			describe 'given the device is online', ->
+
+				beforeEach ->
+					@deviceGetStub = m.sinon.stub(device, 'get')
+					@deviceGetStub.returns Promise.resolve
+						is_online: true
+						ip_address: '10.2.0.78 192.168.2.7'
+						vpn_address: '10.2.0.78'
+
+				afterEach ->
+					@deviceGetStub.restore()
+
+				it 'should eventually be the an array with the local ip address', ->
+					promise = device.getLocalIPAddresses('1234')
+					m.chai.expect(promise).to.eventually.become([ '192.168.2.7' ])
+
+			describe 'given the device is not online', ->
+
+				beforeEach ->
+					@deviceGetStub = m.sinon.stub(device, 'get')
+					@deviceGetStub.returns Promise.resolve
+						is_online: false
+						ip_address: '10.2.0.78 192.168.2.7'
+						vpn_address: '10.2.0.78'
+
+				afterEach ->
+					@deviceGetStub.restore()
+
+				it 'should be rejected with an error message', ->
+					promise = device.getLocalIPAddresses('1234')
+					m.chai.expect(promise).to.be.rejectedWith('The device is offline: 1234')
+
+			describe 'given the device is online, but no local ip exist', ->
+
+				beforeEach ->
+					@deviceGetStub = m.sinon.stub(device, 'get')
+					@deviceGetStub.returns Promise.resolve
+						is_online: true
+						ip_address: '10.2.0.78'
+						vpn_address: '10.2.0.78'
+
+				afterEach ->
+					@deviceGetStub.restore()
+
+				it 'should eventually become an empty array', ->
+					promise = device.getLocalIPAddresses('1234')
+					m.chai.expect(promise).to.eventually.become([])
+
+			describe 'given the device is online and has multiple local ip addresses', ->
+
+				beforeEach ->
+					@deviceGetStub = m.sinon.stub(device, 'get')
+					@deviceGetStub.returns Promise.resolve
+						is_online: true
+						ip_address: '10.2.0.78 192.168.2.7 192.168.2.10'
+						vpn_address: '10.2.0.78'
+
+				afterEach ->
+					@deviceGetStub.restore()
+
+				it 'should eventually be the an array with the local ip addresses', ->
+					promise = device.getLocalIPAddresses('1234')
+					m.chai.expect(promise).to.eventually.become([ '192.168.2.7', '192.168.2.10' ])
+
+		describe '.identify()', ->
+
+			describe 'given the device does not exist', ->
+
+				beforeEach ->
+					@deviceHasStub = m.sinon.stub(device, 'has')
+					@deviceHasStub.returns(Promise.resolve(false))
+
+				afterEach ->
+					@deviceHasStub.restore()
+
+				it 'should be rejected', ->
 					promise = device.identify('1234')
-					m.chai.expect(promise).to.eventually.be.undefined
+					m.chai.expect(promise).to.be.rejectedWith(errors.ResinDeviceNotFound)
 
-	describe '.getDisplayName()', ->
+			describe 'given the device exists', ->
 
-		describe 'given device types', ->
+				beforeEach ->
+					@deviceHasStub = m.sinon.stub(device, 'has')
+					@deviceHasStub.returns(Promise.resolve(true))
 
-			beforeEach ->
-				@configGetDeviceTypesStub = m.sinon.stub(config, 'getDeviceTypes')
-				@configGetDeviceTypesStub.returns Promise.resolve [
-					{ name: 'Raspberry Pi', slug: 'raspberry-pi' }
-					{ name: 'BeagleBone Black', slug: 'beaglebone-black' }
-				]
+				afterEach ->
+					@deviceHasStub.restore()
 
-			afterEach ->
-				@configGetDeviceTypesStub.restore()
+				describe 'given the device is offline', ->
 
-			describe 'given the device slug is valid', ->
+					beforeEach (done) ->
+						settings.get('remoteUrl').then (remoteUrl) ->
+							nock(remoteUrl).post('/blink').reply(404, 'No online device(s) found')
+							done()
 
-				it 'should eventually equal the display name', ->
-					promise = device.getDisplayName('raspberry-pi')
-					m.chai.expect(promise).to.eventually.equal('Raspberry Pi')
+					afterEach ->
+						nock.cleanAll()
 
-			describe 'given the device slug is not valid', ->
+					it 'should be rejected with the correct error message', ->
+						promise = device.identify('1234')
+						m.chai.expect(promise).to.be.rejectedWith('No online device(s) found')
 
-				it 'should eventually be undefined', ->
-					promise = device.getDisplayName('foo-bar')
-					m.chai.expect(promise).to.eventually.be.undefined
+				describe 'given the device is online', ->
 
-	describe '.getDeviceSlug()', ->
+					beforeEach (done) ->
+						settings.get('remoteUrl').then (remoteUrl) ->
+							nock(remoteUrl).post('/blink').reply(200)
+							done()
 
-		describe 'given device types', ->
+					afterEach ->
+						nock.cleanAll()
 
-			beforeEach ->
-				@configGetDeviceTypesStub = m.sinon.stub(config, 'getDeviceTypes')
-				@configGetDeviceTypesStub.returns Promise.resolve [
-					{ name: 'Raspberry Pi', slug: 'raspberry-pi' }
-					{ name: 'BeagleBone Black', slug: 'beaglebone-black' }
-				]
+					it 'should eventually be undefined', ->
+						promise = device.identify('1234')
+						m.chai.expect(promise).to.eventually.be.undefined
 
-			afterEach ->
-				@configGetDeviceTypesStub.restore()
+		describe '.getDisplayName()', ->
 
-			describe 'given the device name is valid', ->
+			describe 'given device types', ->
 
-				it 'should eventually equal the device slug', ->
-					promise = device.getDeviceSlug('Raspberry Pi')
-					m.chai.expect(promise).to.eventually.equal('raspberry-pi')
+				beforeEach ->
+					@configGetDeviceTypesStub = m.sinon.stub(config, 'getDeviceTypes')
+					@configGetDeviceTypesStub.returns Promise.resolve [
+						{ name: 'Raspberry Pi', slug: 'raspberry-pi' }
+						{ name: 'BeagleBone Black', slug: 'beaglebone-black' }
+					]
 
-			describe 'given the device name is not valid', ->
+				afterEach ->
+					@configGetDeviceTypesStub.restore()
 
-				it 'should eventually be undefined', ->
-					promise = device.getDeviceSlug('Foo Bar')
-					m.chai.expect(promise).to.eventually.be.undefined
+				describe 'given the device slug is valid', ->
 
-	describe '.getSupportedDeviceTypes()', ->
+					it 'should eventually equal the display name', ->
+						promise = device.getDisplayName('raspberry-pi')
+						m.chai.expect(promise).to.eventually.equal('Raspberry Pi')
 
-		describe 'given device types', ->
+				describe 'given the device slug is not valid', ->
 
-			beforeEach ->
-				@configGetDeviceTypesStub = m.sinon.stub(config, 'getDeviceTypes')
-				@configGetDeviceTypesStub.returns Promise.resolve [
-					{ name: 'Raspberry Pi', slug: 'raspberry-pi' }
-					{ name: 'BeagleBone Black', slug: 'beaglebone-black' }
-				]
+					it 'should eventually be undefined', ->
+						promise = device.getDisplayName('foo-bar')
+						m.chai.expect(promise).to.eventually.be.undefined
 
-			afterEach ->
-				@configGetDeviceTypesStub.restore()
+		describe '.getDeviceSlug()', ->
 
-			it 'should eventually become an array of names', ->
-				promise = device.getSupportedDeviceTypes()
-				m.chai.expect(promise).to.eventually.become([ 'Raspberry Pi', 'BeagleBone Black' ])
+			describe 'given device types', ->
 
-	describe '.getManifestBySlug()', ->
+				beforeEach ->
+					@configGetDeviceTypesStub = m.sinon.stub(config, 'getDeviceTypes')
+					@configGetDeviceTypesStub.returns Promise.resolve [
+						{ name: 'Raspberry Pi', slug: 'raspberry-pi' }
+						{ name: 'BeagleBone Black', slug: 'beaglebone-black' }
+					]
 
-		describe 'given device types', ->
+				afterEach ->
+					@configGetDeviceTypesStub.restore()
 
-			beforeEach ->
-				@configGetDeviceTypesStub = m.sinon.stub(config, 'getDeviceTypes')
-				@configGetDeviceTypesStub.returns Promise.resolve [
-					{ name: 'Raspberry Pi', slug: 'raspberry-pi' }
-					{ name: 'BeagleBone Black', slug: 'beaglebone-black' }
-				]
+				describe 'given the device name is valid', ->
 
-			afterEach ->
-				@configGetDeviceTypesStub.restore()
+					it 'should eventually equal the device slug', ->
+						promise = device.getDeviceSlug('Raspberry Pi')
+						m.chai.expect(promise).to.eventually.equal('raspberry-pi')
 
-			it 'should be rejected if no slug', ->
-				promise = device.getManifestBySlug('foo-bar')
-				m.chai.expect(promise).to.be.rejectedWith('Unsupported device: foo-bar')
+				describe 'given the device name is not valid', ->
 
-			it 'should eventually become the manifest if slug is valid', ->
-				promise = device.getManifestBySlug('raspberry-pi')
-				m.chai.expect(promise).to.eventually.become
-					name: 'Raspberry Pi'
-					slug: 'raspberry-pi'
+					it 'should eventually be undefined', ->
+						promise = device.getDeviceSlug('Foo Bar')
+						m.chai.expect(promise).to.eventually.be.undefined
 
-	describe '.generateUUID()', ->
+		describe '.getSupportedDeviceTypes()', ->
 
-		it 'should return a string', ->
-			uuid = device.generateUUID()
-			m.chai.expect(uuid).to.be.a('string')
+			describe 'given device types', ->
 
-		it 'should have a length of 62 (31 bytes)', ->
-			uuid = device.generateUUID()
-			m.chai.expect(uuid).to.have.length(62)
+				beforeEach ->
+					@configGetDeviceTypesStub = m.sinon.stub(config, 'getDeviceTypes')
+					@configGetDeviceTypesStub.returns Promise.resolve [
+						{ name: 'Raspberry Pi', slug: 'raspberry-pi' }
+						{ name: 'BeagleBone Black', slug: 'beaglebone-black' }
+					]
 
-		it 'should generate different uuids each time', ->
-			uuid1 = device.generateUUID()
-			uuid2 = device.generateUUID()
-			uuid3 = device.generateUUID()
+				afterEach ->
+					@configGetDeviceTypesStub.restore()
 
-			m.chai.expect(uuid1).to.not.equal(uuid2)
-			m.chai.expect(uuid2).to.not.equal(uuid3)
-			m.chai.expect(uuid3).to.not.equal(uuid1)
+				it 'should eventually become an array of names', ->
+					promise = device.getSupportedDeviceTypes()
+					m.chai.expect(promise).to.eventually.become([ 'Raspberry Pi', 'BeagleBone Black' ])
+
+		describe '.getManifestBySlug()', ->
+
+			describe 'given device types', ->
+
+				beforeEach ->
+					@configGetDeviceTypesStub = m.sinon.stub(config, 'getDeviceTypes')
+					@configGetDeviceTypesStub.returns Promise.resolve [
+						{ name: 'Raspberry Pi', slug: 'raspberry-pi' }
+						{ name: 'BeagleBone Black', slug: 'beaglebone-black' }
+					]
+
+				afterEach ->
+					@configGetDeviceTypesStub.restore()
+
+				it 'should be rejected if no slug', ->
+					promise = device.getManifestBySlug('foo-bar')
+					m.chai.expect(promise).to.be.rejectedWith('Unsupported device: foo-bar')
+
+				it 'should eventually become the manifest if slug is valid', ->
+					promise = device.getManifestBySlug('raspberry-pi')
+					m.chai.expect(promise).to.eventually.become
+						name: 'Raspberry Pi'
+						slug: 'raspberry-pi'
+
+		describe '.generateUUID()', ->
+
+			it 'should return a string', ->
+				uuid = device.generateUUID()
+				m.chai.expect(uuid).to.be.a('string')
+
+			it 'should have a length of 62 (31 bytes)', ->
+				uuid = device.generateUUID()
+				m.chai.expect(uuid).to.have.length(62)
+
+			it 'should generate different uuids each time', ->
+				uuid1 = device.generateUUID()
+				uuid2 = device.generateUUID()
+				uuid3 = device.generateUUID()
+
+				m.chai.expect(uuid1).to.not.equal(uuid2)
+				m.chai.expect(uuid2).to.not.equal(uuid3)
+				m.chai.expect(uuid3).to.not.equal(uuid1)

--- a/tests/models/os.spec.coffee
+++ b/tests/models/os.spec.coffee
@@ -3,47 +3,58 @@ nock = require('nock')
 Promise = require('bluebird')
 settings = require('../../lib/settings')
 os = require('../../lib/models/os')
+johnDoeFixture = require('../tokens.json').johndoe
 
 describe 'OS Model:', ->
 
-	describe '.download()', ->
+	describe 'given a /whoami endpoint', ->
 
-		describe 'given valid parameters', ->
+		beforeEach (done) ->
+			settings.get('remoteUrl').then (remoteUrl) ->
+				nock(remoteUrl).get('/whoami').reply(200, johnDoeFixture.token)
+				done()
 
-			beforeEach (done) ->
-				settings.get('remoteUrl').then (remoteUrl) ->
-					nock(remoteUrl).get('/download?network=ethernet&appId=95')
-						.reply(200, 'Lorem ipsum dolor sit amet')
-					done()
+		afterEach ->
+			nock.cleanAll()
 
-			afterEach ->
-				nock.cleanAll()
+		describe '.download()', ->
 
-			it 'should stream the download', (done) ->
-				os.download
-					network: 'ethernet'
-					appId: 95
-				.then (stream) ->
-					result = ''
-					stream.on 'data', (chunk) -> result += chunk
-					stream.on 'end', ->
-						m.chai.expect(result).to.equal('Lorem ipsum dolor sit amet')
+			describe 'given valid parameters', ->
+
+				beforeEach (done) ->
+					settings.get('remoteUrl').then (remoteUrl) ->
+						nock(remoteUrl).get('/download?network=ethernet&appId=95')
+							.reply(200, 'Lorem ipsum dolor sit amet')
 						done()
 
-		describe 'given invalid parameters', ->
+				afterEach ->
+					nock.cleanAll()
 
-			beforeEach (done) ->
-				settings.get('remoteUrl').then (remoteUrl) ->
-					nock(remoteUrl).get('/download?network=ethernet&appId=95')
-						.reply(400, 'Invalid application name')
-					done()
+				it 'should stream the download', (done) ->
+					os.download
+						network: 'ethernet'
+						appId: 95
+					.then (stream) ->
+						result = ''
+						stream.on 'data', (chunk) -> result += chunk
+						stream.on 'end', ->
+							m.chai.expect(result).to.equal('Lorem ipsum dolor sit amet')
+							done()
 
-			afterEach ->
-				nock.cleanAll()
+			describe 'given invalid parameters', ->
 
-			it 'should be rejected with an error message', ->
-				promise = os.download
-					network: 'ethernet'
-					appId: 95
+				beforeEach (done) ->
+					settings.get('remoteUrl').then (remoteUrl) ->
+						nock(remoteUrl).get('/download?network=ethernet&appId=95')
+							.reply(400, 'Invalid application name')
+						done()
 
-				m.chai.expect(promise).to.be.rejectedWith('Invalid application name')
+				afterEach ->
+					nock.cleanAll()
+
+				it 'should be rejected with an error message', ->
+					promise = os.download
+						network: 'ethernet'
+						appId: 95
+
+					m.chai.expect(promise).to.be.rejectedWith('Invalid application name')


### PR DESCRIPTION
This change includes token refresh logic, which is critical to avoid users getting an invalid token after a while.