### PR TITLE
Upgrade Resin Token to v2.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "resin-device-logs": "^1.0.0",
     "resin-errors": "^2.0.0",
     "resin-request": "^2.2.3",
-    "resin-token": "^2.3.0",
+    "resin-token": "^2.4.1",
     "resin-pine": "^1.3.0",
     "resin-settings-client": "^2.0.0"
   }


### PR DESCRIPTION
This version contains a fix to ENOENT intermitent issues in the SDK test
suite.