### PR TITLE
Request GET /whoami to determine if a user is logged in

### DIFF
--- a/build/auth.js
+++ b/build/auth.js
@@ -184,7 +184,12 @@ THE SOFTWARE.
    */
 
   exports.isLoggedIn = function(callback) {
-    return token.has().nodeify(callback);
+    return request.send({
+      method: 'GET',
+      url: '/whoami'
+    })["return"](true)["catch"](function() {
+      return false;
+    }).nodeify(callback);
   };
 
 

--- a/lib/auth.coffee
+++ b/lib/auth.coffee
@@ -167,7 +167,13 @@ exports.loginWithToken = (authToken, callback) ->
 # 		console.log('Too bad!')
 ###
 exports.isLoggedIn = (callback) ->
-	token.has().nodeify(callback)
+	request.send
+		method: 'GET'
+		url: '/whoami'
+	.return(true)
+	.catch ->
+		return false
+	.nodeify(callback)
 
 ###*
 # @summary Get current logged in user's token

--- a/tests/auth.spec.coffee
+++ b/tests/auth.spec.coffee
@@ -172,8 +172,13 @@ describe 'Auth:', ->
 
 			describe 'given a logged in user', ->
 
-				beforeEach ->
-					auth.loginWithToken(janeDoeFixture.token)
+				beforeEach (done) ->
+					settings.get('remoteUrl').then (remoteUrl) ->
+						nock(remoteUrl).get('/whoami').reply(200, janeDoeFixture.token)
+						done()
+
+				afterEach ->
+					nock.cleanAll()
 
 				it 'should eventually be true', ->
 					promise = auth.isLoggedIn()
@@ -181,8 +186,13 @@ describe 'Auth:', ->
 
 			describe 'given no logged in user', ->
 
-				beforeEach ->
-					auth.logout()
+				beforeEach (done) ->
+					settings.get('remoteUrl').then (remoteUrl) ->
+						nock(remoteUrl).get('/whoami').reply(401, 'Unauthorized')
+						done()
+
+				afterEach ->
+					nock.cleanAll()
 
 				it 'should eventually be false', ->
 					promise = auth.isLoggedIn()


### PR DESCRIPTION
The current approach consisted in checking that there was a saved token,
however this ignored the fact that the token might be out of date, or
even not valid at all, resulting in false positives from
`resin.auth.isLoggedIn()`.

The alternative is to trigger an HTTP request to GET /whoami, which if
sent a valid token, it will return 200, and 401 otherwise.