### PR TITLE
Coerce device env vars `env_var_name` to `name`

### DIFF
--- a/build/models/environment-variables.js
+++ b/build/models/environment-variables.js
@@ -224,6 +224,12 @@ THE SOFTWARE.
           orderby: 'env_var_name asc'
         }
       });
+    }).map(function(environmentVariable) {
+      if (environmentVariable.env_var_name != null) {
+        environmentVariable.name = environmentVariable.env_var_name;
+        delete environmentVariable.env_var_name;
+      }
+      return environmentVariable;
     }).nodeify(callback);
   };
 

--- a/lib/models/environment-variables.coffee
+++ b/lib/models/environment-variables.coffee
@@ -190,6 +190,16 @@ exports.device.getAll = (uuid, callback) ->
 					device: device.id
 				expand: 'device'
 				orderby: 'env_var_name asc'
+	.map (environmentVariable) ->
+
+		# Workaround to the fact that applications environment variables
+		# contains a `name` property, while device environment variables
+		# contains an `env_var_name` property instead.
+		if environmentVariable.env_var_name?
+			environmentVariable.name = environmentVariable.env_var_name
+			delete environmentVariable.env_var_name
+		return environmentVariable
+
 	.nodeify(callback)
 
 ###*


### PR DESCRIPTION
Workaround to the fact that applications environment variables
contains a `name` property, while device environment variables
contains an `env_var_name` property instead.

This fixes:

- https://github.com/resin-io/resin-cli/issues/120