### PR TITLE
Set RESIN and USER as system environment variables

### DIFF
--- a/build/models/environment-variables.js
+++ b/build/models/environment-variables.js
@@ -180,7 +180,7 @@ THE SOFTWARE.
    */
 
   exports.isSystemVariable = function(variable) {
-    return /^RESIN_/.test(variable.name);
+    return /^RESIN_|^RESIN$|^USER$/.test(variable.name);
   };
 
 

--- a/lib/models/environment-variables.coffee
+++ b/lib/models/environment-variables.coffee
@@ -154,7 +154,7 @@ exports.remove = (id, callback) ->
 # > false
 ####
 exports.isSystemVariable = (variable) ->
-	return /^RESIN_/.test(variable.name)
+	return /^RESIN_|^RESIN$|^USER$/.test(variable.name)
 
 ###*
 # @namespace resin.models.environment-variables.device

--- a/tests/models/environment-variables.spec.coffee
+++ b/tests/models/environment-variables.spec.coffee
@@ -45,8 +45,24 @@ describe 'Environment Variables Model:', ->
 				result = environmentVariables.isSystemVariable(name: 'RESIN_VAR')
 				m.chai.expect(result).to.be.true
 
+			it 'should return true for RESIN', ->
+				result = environmentVariables.isSystemVariable(name: 'RESIN')
+				m.chai.expect(result).to.be.true
+
+			it 'should return true for USER', ->
+				result = environmentVariables.isSystemVariable(name: 'USER')
+				m.chai.expect(result).to.be.true
+
 		describe 'given a non system variable', ->
 
 			it 'should return false for EDITOR', ->
 				result = environmentVariables.isSystemVariable(name: 'EDITOR')
+				m.chai.expect(result).to.be.false
+
+			it 'should return false for RESINATOR', ->
+				result = environmentVariables.isSystemVariable(name: 'RESINATOR')
+				m.chai.expect(result).to.be.false
+
+			it 'should return false for SOME_USER', ->
+				result = environmentVariables.isSystemVariable(name: 'SOME_USER')
 				m.chai.expect(result).to.be.false


### PR DESCRIPTION
Previously, only environment variables starting with `RESIN_` were
considered system environment variables, however, the UI also defines
`RESIN` and `USER` as reserved names.

This PR modified `resin.models.environmentVariables.isSystemVariable()`
to account for those cases.

Fixes: https://github.com/resin-io/resin-sdk/issues/124