### PR TITLE
Upgrade Resin Request to v2.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "lodash": "~3.9.1",
     "resin-device-logs": "^1.0.0",
     "resin-errors": "^2.0.0",
-    "resin-request": "^2.2.3",
+    "resin-request": "^2.2.4",
     "resin-token": "^2.4.1",
     "resin-pine": "^1.3.0",
     "resin-settings-client": "^2.1.0"


### PR DESCRIPTION
This version contains a fix that allows `resin.model.os.download()` to
work as expected when piping to multiple locations.