### PR TITLE
Allow extra os parameters when downloading an image

### DIFF
--- a/build/models/os-params.js
+++ b/build/models/os-params.js
@@ -24,7 +24,7 @@ THE SOFTWARE.
  */
 
 (function() {
-  var NETWORK_ETHERNET, NETWORK_TYPES, NETWORK_WIFI, OSParams, VALID_OPTIONS, _;
+  var NETWORK_ETHERNET, NETWORK_TYPES, NETWORK_WIFI, OSParams, _;
 
   _ = require('lodash');
 
@@ -33,8 +33,6 @@ THE SOFTWARE.
   NETWORK_ETHERNET = 'ethernet';
 
   NETWORK_TYPES = [NETWORK_WIFI, NETWORK_ETHERNET];
-
-  VALID_OPTIONS = ['network', 'appId', 'wifiSsid', 'wifiKey'];
 
 
   /**
@@ -55,7 +53,6 @@ THE SOFTWARE.
 
   module.exports = OSParams = (function() {
     function OSParams(options) {
-      var invalidOptions;
       if (options.appId == null) {
         throw new Error('Missing option: appId');
       }
@@ -76,10 +73,6 @@ THE SOFTWARE.
         if (options.wifiKey == null) {
           throw new Error('Missing option: wifiKey');
         }
-      }
-      invalidOptions = _.difference(_.keys(options), VALID_OPTIONS);
-      if (!_.isEmpty(invalidOptions)) {
-        throw new Error("Non allowed option: " + (_.first(invalidOptions)));
       }
       _.extend(this, options);
     }

--- a/lib/models/os-params.coffee
+++ b/lib/models/os-params.coffee
@@ -32,13 +32,6 @@ NETWORK_TYPES = [
 	NETWORK_ETHERNET
 ]
 
-VALID_OPTIONS = [
-	'network'
-	'appId'
-	'wifiSsid'
-	'wifiKey'
-]
-
 ###*
 # Create a set of connection parameters
 # @name OSParams
@@ -78,10 +71,5 @@ module.exports = class OSParams
 
 			if not options.wifiKey?
 				throw new Error('Missing option: wifiKey')
-
-		invalidOptions = _.difference(_.keys(options), VALID_OPTIONS)
-
-		if not _.isEmpty(invalidOptions)
-			throw new Error("Non allowed option: #{_.first(invalidOptions)}")
 
 		_.extend(this, options)

--- a/tests/models/os-params.spec.coffee
+++ b/tests/models/os-params.spec.coffee
@@ -67,10 +67,10 @@ describe 'OS Params:', ->
 
 			m.chai.expect(connectionParams.appId).to.equal(91)
 
-		it 'should throw an error if extra options', ->
-			m.chai.expect ->
-				new OSParams
-					network: 'ethernet'
-					appId: '91'
-					hello: 'world'
-			.to.throw('Non allowed option: hello')
+		it 'should save extra options', ->
+			connectionParams = new OSParams
+				network: 'ethernet'
+				appId: '91'
+				hello: 'world'
+
+			m.chai.expect(connectionParams.hello).to.equal('world')


### PR DESCRIPTION
Since the parameters required are not just network related anymore, and
device specs may introduce new ones at any time, we remove the valid
parameter constraint to avoid having to mantain a hardcoded list in the
SDK.