### PR TITLE
Implement `resin.models.config.getDeviceOptions()`

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -63,6 +63,7 @@ If you feel something is missing, not clear or could be improved, please don't h
       * [.getAll()](#resin.models.config.getAll) ⇒ <code>Promise</code>
       * [.getPubNubKeys()](#resin.models.config.getPubNubKeys) ⇒ <code>Promise</code>
       * [.getDeviceTypes()](#resin.models.config.getDeviceTypes) ⇒ <code>Promise</code>
+      * [.getDeviceOptions(deviceType)](#resin.models.config.getDeviceOptions) ⇒ <code>Promise</code>
   * [.auth](#resin.auth) : <code>object</code>
     * [.whoami()](#resin.auth.whoami) ⇒ <code>Promise</code>
     * [.authenticate(credentials)](#resin.auth.authenticate) ⇒ <code>Promise</code>
@@ -139,6 +140,7 @@ If you feel something is missing, not clear or could be improved, please don't h
     * [.getAll()](#resin.models.config.getAll) ⇒ <code>Promise</code>
     * [.getPubNubKeys()](#resin.models.config.getPubNubKeys) ⇒ <code>Promise</code>
     * [.getDeviceTypes()](#resin.models.config.getDeviceTypes) ⇒ <code>Promise</code>
+    * [.getDeviceOptions(deviceType)](#resin.models.config.getDeviceOptions) ⇒ <code>Promise</code>
 
 <a name="resin.models.application"></a>
 #### models.application : <code>object</code>
@@ -1133,6 +1135,7 @@ resin.models.os.download parameters, (error, stream) ->
   * [.getAll()](#resin.models.config.getAll) ⇒ <code>Promise</code>
   * [.getPubNubKeys()](#resin.models.config.getPubNubKeys) ⇒ <code>Promise</code>
   * [.getDeviceTypes()](#resin.models.config.getDeviceTypes) ⇒ <code>Promise</code>
+  * [.getDeviceOptions(deviceType)](#resin.models.config.getDeviceOptions) ⇒ <code>Promise</code>
 
 <a name="resin.models.config.getAll"></a>
 ##### config.getAll() ⇒ <code>Promise</code>
@@ -1186,6 +1189,28 @@ resin.models.config.getDeviceTypes().then (deviceTypes) ->
 resin.models.config.getDeviceTypes (error, deviceTypes) ->
 	throw error if error?
 	console.log(deviceTypes)
+```
+<a name="resin.models.config.getDeviceOptions"></a>
+##### config.getDeviceOptions(deviceType) ⇒ <code>Promise</code>
+**Kind**: static method of <code>[config](#resin.models.config)</code>  
+**Summary**: Get configuration/initialization options for a device type  
+**Access:** public  
+**Fulfil**: <code>Object[]</code> - configuration options  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| deviceType | <code>String</code> | device type slug |
+
+**Example**  
+```js
+resin.models.config.getDeviceOptions('raspberry-pi').then (options) ->
+	console.log(options)
+```
+**Example**  
+```js
+resin.models.config.getDeviceOptions 'raspberry-pi', (error, options) ->
+	throw error if error?
+	console.log(options)
 ```
 <a name="resin.auth"></a>
 ### resin.auth : <code>object</code>

--- a/build/models/config.js
+++ b/build/models/config.js
@@ -24,9 +24,13 @@ THE SOFTWARE.
  */
 
 (function() {
-  var request;
+  var _, deviceModel, request;
+
+  _ = require('lodash');
 
   request = require('resin-request');
+
+  deviceModel = require('./device');
 
 
   /**
@@ -113,6 +117,37 @@ THE SOFTWARE.
       if (deviceTypes == null) {
         throw new Error('No device types');
       }
+    }).nodeify(callback);
+  };
+
+
+  /**
+   * @summary Get configuration/initialization options for a device type
+   * @name getDeviceOptions
+   * @public
+   * @function
+   * @memberof resin.models.config
+   *
+   * @param {String} deviceType - device type slug
+   * @fulfil {Object[]} - configuration options
+   * @returns {Promise}
+   *
+   * @example
+   * resin.models.config.getDeviceOptions('raspberry-pi').then (options) ->
+   * 	console.log(options)
+   *
+   * @example
+   * resin.models.config.getDeviceOptions 'raspberry-pi', (error, options) ->
+   * 	throw error if error?
+   * 	console.log(options)
+   */
+
+  exports.getDeviceOptions = function(deviceType, callback) {
+    return deviceModel.getManifestBySlug(deviceType).then(function(manifest) {
+      if (manifest.initialization == null) {
+        manifest.initialization = {};
+      }
+      return _.union(manifest.options, manifest.initialization.options);
     }).nodeify(callback);
   };
 

--- a/lib/models/config.coffee
+++ b/lib/models/config.coffee
@@ -22,7 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ###
 
+_ = require('lodash')
 request = require('resin-request')
+deviceModel = require('./device')
 
 ###*
 # @summary Get all configuration
@@ -100,4 +102,30 @@ exports.getDeviceTypes = (callback) ->
 	exports.getAll().get('deviceTypes').tap (deviceTypes) ->
 		if not deviceTypes?
 			throw new Error('No device types')
+	.nodeify(callback)
+
+###*
+# @summary Get configuration/initialization options for a device type
+# @name getDeviceOptions
+# @public
+# @function
+# @memberof resin.models.config
+#
+# @param {String} deviceType - device type slug
+# @fulfil {Object[]} - configuration options
+# @returns {Promise}
+#
+# @example
+# resin.models.config.getDeviceOptions('raspberry-pi').then (options) ->
+# 	console.log(options)
+#
+# @example
+# resin.models.config.getDeviceOptions 'raspberry-pi', (error, options) ->
+# 	throw error if error?
+# 	console.log(options)
+###
+exports.getDeviceOptions = (deviceType, callback) ->
+	deviceModel.getManifestBySlug(deviceType).then (manifest) ->
+		manifest.initialization ?= {}
+		return _.union(manifest.options, manifest.initialization.options)
 	.nodeify(callback)

--- a/tests/models/config.spec.coffee
+++ b/tests/models/config.spec.coffee
@@ -2,6 +2,7 @@ m = require('mochainon')
 Promise = require('bluebird')
 nock = require('nock')
 settings = require('../../lib/settings')
+device = require('../../lib/models/device')
 config = require('../../lib/models/config')
 johnDoeFixture = require('../tokens.json').johndoe
 
@@ -100,3 +101,106 @@ describe 'Config Model:', ->
 				it 'should reject with an error message', ->
 					promise = config.getDeviceTypes()
 					m.chai.expect(promise).to.be.rejectedWith('No device types')
+
+		describe '.getDeviceOptions()', ->
+
+			describe 'given a manifest with configuration options', ->
+
+				beforeEach ->
+					@deviceGetManifestBySlugStub = m.sinon.stub(device, 'getManifestBySlug')
+					@deviceGetManifestBySlugStub.returns Promise.resolve
+						options: [
+							message: 'Processor'
+							name: 'processorType'
+							type: 'list'
+							choices: [ 'Z7010', 'Z7020' ]
+						,
+							message: 'Coprocessor cores'
+							name: 'coprocessorCore'
+							type: 'list'
+							choices: [ '16', '64' ]
+						]
+
+				afterEach ->
+					@deviceGetManifestBySlugStub.restore()
+
+				it 'should become the configuration options', ->
+					promise = config.getDeviceOptions('mydevicetype')
+					m.chai.expect(promise).to.become [
+						message: 'Processor'
+						name: 'processorType'
+						type: 'list'
+						choices: [ 'Z7010', 'Z7020' ]
+					,
+						message: 'Coprocessor cores'
+						name: 'coprocessorCore'
+						type: 'list'
+						choices: [ '16', '64' ]
+					]
+
+			describe 'given a manifest with initialization options', ->
+
+				beforeEach ->
+					@deviceGetManifestBySlugStub = m.sinon.stub(device, 'getManifestBySlug')
+					@deviceGetManifestBySlugStub.returns Promise.resolve
+						initialization:
+							options: [
+								message: 'Select a drive'
+								type: 'drive'
+								name: 'drive'
+							]
+
+				afterEach ->
+					@deviceGetManifestBySlugStub.restore()
+
+				it 'should become the initialization options', ->
+					promise = config.getDeviceOptions('mydevicetype')
+					m.chai.expect(promise).to.become [
+						message: 'Select a drive'
+						type: 'drive'
+						name: 'drive'
+					]
+
+			describe 'given a manifest with configuration and initialization options', ->
+
+				beforeEach ->
+					@deviceGetManifestBySlugStub = m.sinon.stub(device, 'getManifestBySlug')
+					@deviceGetManifestBySlugStub.returns Promise.resolve
+						options: [
+							message: 'Processor'
+							name: 'processorType'
+							type: 'list'
+							choices: [ 'Z7010', 'Z7020' ]
+						,
+							message: 'Coprocessor cores'
+							name: 'coprocessorCore'
+							type: 'list'
+							choices: [ '16', '64' ]
+						]
+						initialization:
+							options: [
+								message: 'Select a drive'
+								type: 'drive'
+								name: 'drive'
+							]
+
+				afterEach ->
+					@deviceGetManifestBySlugStub.restore()
+
+				it 'shoulde become an union of both', ->
+					promise = config.getDeviceOptions('mydevicetype')
+					m.chai.expect(promise).to.become [
+							message: 'Processor'
+							name: 'processorType'
+							type: 'list'
+							choices: [ 'Z7010', 'Z7020' ]
+						,
+							message: 'Coprocessor cores'
+							name: 'coprocessorCore'
+							type: 'list'
+							choices: [ '16', '64' ]
+						,
+							message: 'Select a drive'
+							type: 'drive'
+							name: 'drive'
+					]


### PR DESCRIPTION
This function is used to get an union of the configuration and
initialization options defined in a device spec for a specific device
type.

This function will be used by the CLI to ask the appropriate questions
when initializing a device.