### PR TITLE
Document use of device slugs in application.create()

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -265,16 +265,16 @@ resin.models.application.getById 89, (error, application) ->
 | Param | Type | Description |
 | --- | --- | --- |
 | name | <code>String</code> | application name |
-| deviceType | <code>String</code> | device type (display form) |
+| deviceType | <code>String</code> | device type slug |
 
 **Example**  
 ```js
-resin.models.application.create('My App', 'Raspberry Pi').then (id) ->
+resin.models.application.create('My App', 'raspberry-pi').then (id) ->
 	console.log(id)
 ```
 **Example**  
 ```js
-resin.models.application.create 'My App', 'Raspberry Pi', (error, id) ->
+resin.models.application.create 'My App', 'raspberry-pi', (error, id) ->
 	throw error if error?
 	console.log(id)
 ```

--- a/build/models/application.js
+++ b/build/models/application.js
@@ -208,17 +208,17 @@ THE SOFTWARE.
    * @memberof resin.models.application
    *
    * @param {String} name - application name
-   * @param {String} deviceType - device type (display form)
+   * @param {String} deviceType - device type slug
    *
    * @fulfil {Number} - application id
    * @returns {Promise}
    *
    * @example
-   * resin.models.application.create('My App', 'Raspberry Pi').then (id) ->
+   * resin.models.application.create('My App', 'raspberry-pi').then (id) ->
    * 	console.log(id)
    *
    * @example
-   * resin.models.application.create 'My App', 'Raspberry Pi', (error, id) ->
+   * resin.models.application.create 'My App', 'raspberry-pi', (error, id) ->
    * 	throw error if error?
    * 	console.log(id)
    */

--- a/lib/models/application.coffee
+++ b/lib/models/application.coffee
@@ -183,17 +183,17 @@ exports.getById = (id, callback) ->
 # @memberof resin.models.application
 #
 # @param {String} name - application name
-# @param {String} deviceType - device type (display form)
+# @param {String} deviceType - device type slug
 #
 # @fulfil {Number} - application id
 # @returns {Promise}
 #
 # @example
-# resin.models.application.create('My App', 'Raspberry Pi').then (id) ->
+# resin.models.application.create('My App', 'raspberry-pi').then (id) ->
 # 	console.log(id)
 #
 # @example
-# resin.models.application.create 'My App', 'Raspberry Pi', (error, id) ->
+# resin.models.application.create 'My App', 'raspberry-pi', (error, id) ->
 # 	throw error if error?
 # 	console.log(id)
 ###


### PR DESCRIPTION
Current documentation gives the impression that only display form of
device types are accepted.

We change all documentation to reflects slugs instead, since it's very
unlikely (and awkward) that someone will use display names here.