### PR TITLE
Fix Unauthorized error on authenticate()

### DIFF
--- a/build/auth.js
+++ b/build/auth.js
@@ -101,7 +101,8 @@ THE SOFTWARE.
     return request.send({
       method: 'POST',
       url: '/login_',
-      body: credentials
+      body: credentials,
+      refreshToken: false
     }).get('body').nodeify(callback);
   };
 

--- a/lib/auth.coffee
+++ b/lib/auth.coffee
@@ -91,6 +91,7 @@ exports.authenticate = (credentials, callback) ->
 		method: 'POST'
 		url: '/login_'
 		body: credentials
+		refreshToken: false
 	.get('body')
 	.nodeify(callback)
 


### PR DESCRIPTION
Resin Request was modified to automatically attempt to refresh the token
once it's validity was considered "soon to be expired".

When using `resin.auth.authenticate()`, Resin Request attempted to
refresh the token, however there is no token at that point, resulting in
a 401 from `/whoami`.

The solution is simply not refreshing the token when attempting to
authenticate.

Fixes: https://github.com/resin-io/resin-sdk/issues/135