### PR TITLE
Reuse resin-device-register

### DIFF
--- a/build/models/device.js
+++ b/build/models/device.js
@@ -24,7 +24,7 @@ THE SOFTWARE.
  */
 
 (function() {
-  var Promise, _, applicationModel, auth, configModel, crypto, errors, pine, request;
+  var Promise, _, applicationModel, auth, configModel, crypto, errors, pine, registerDevice, request;
 
   Promise = require('bluebird');
 
@@ -37,6 +37,8 @@ THE SOFTWARE.
   errors = require('resin-errors');
 
   request = require('resin-request');
+
+  registerDevice = require('resin-register-device');
 
   configModel = require('./config');
 
@@ -665,9 +667,7 @@ THE SOFTWARE.
    * uuid = resin.models.device.generateUUID()
    */
 
-  exports.generateUUID = function() {
-    return crypto.pseudoRandomBytes(31).toString('hex');
-  };
+  exports.generateUUID = registerDevice.generateUUID;
 
 
   /**
@@ -701,18 +701,12 @@ THE SOFTWARE.
       apiKey: applicationModel.getApiKey(applicationName),
       application: applicationModel.get(applicationName)
     }).then(function(results) {
-      return pine.post({
-        resource: 'device',
-        body: {
-          user: results.userId,
-          application: results.application.id,
-          device_type: results.application.device_type,
-          registered_at: Math.floor(Date.now() / 1000),
-          uuid: uuid
-        },
-        customOptions: {
-          apikey: results.apiKey
-        }
+      return registerDevice.register(pine, {
+        userId: results.userId,
+        applicationId: results.application.id,
+        deviceType: results.application.device_type,
+        uuid: uuid,
+        apiKey: results.apiKey
       });
     }).nodeify(callback);
   };

--- a/package.json
+++ b/package.json
@@ -43,9 +43,10 @@
     "lodash": "~3.9.1",
     "resin-device-logs": "^1.0.0",
     "resin-errors": "^2.0.0",
-    "resin-request": "^2.3.1",
-    "resin-token": "^2.4.1",
     "resin-pine": "^1.3.0",
-    "resin-settings-client": "^2.1.0"
+    "resin-register-device": "^1.1.0",
+    "resin-request": "^2.3.1",
+    "resin-settings-client": "^2.1.0",
+    "resin-token": "^2.4.1"
   }
 }


### PR DESCRIPTION
This module is now used to:

- Provide `resin.models.device.generateUUID()`.
- Provide `resin.models.device.register()`.

The purpose is to make `resin-device-register` the only source of truth
of behaviour to generate a uuid and register a device, since that module
is already being used by the Supervisor.

See: https://github.com/resin-io/resin-register-device