### PR TITLE
Make generateUUID() async

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "resin-device-logs": "^1.0.0",
     "resin-errors": "^2.0.0",
     "resin-pine": "^1.3.1",
-    "resin-register-device": "^1.1.0",
+    "resin-register-device": "^2.0.0",
     "resin-request": "^2.3.2",
     "resin-settings-client": "^3.1.0",
     "resin-token": "^2.4.2"

--- a/tests/models/device.spec.coffee
+++ b/tests/models/device.spec.coffee
@@ -683,21 +683,23 @@ describe 'Device Model:', ->
 		describe '.generateUUID()', ->
 
 			it 'should return a string', ->
-				uuid = device.generateUUID()
-				m.chai.expect(uuid).to.be.a('string')
+				promise = device.generateUUID()
+				m.chai.expect(promise).to.eventually.be.a('string')
 
 			it 'should have a length of 62 (31 bytes)', ->
-				uuid = device.generateUUID()
-				m.chai.expect(uuid).to.have.length(62)
+				promise = device.generateUUID()
+				m.chai.expect(promise).to.eventually.have.length(62)
 
-			it 'should generate different uuids each time', ->
-				uuid1 = device.generateUUID()
-				uuid2 = device.generateUUID()
-				uuid3 = device.generateUUID()
-
-				m.chai.expect(uuid1).to.not.equal(uuid2)
-				m.chai.expect(uuid2).to.not.equal(uuid3)
-				m.chai.expect(uuid3).to.not.equal(uuid1)
+			it 'should generate different uuids each time', (done) ->
+				Promise.props
+					one: device.generateUUID()
+					two: device.generateUUID()
+					three: device.generateUUID()
+				.then (uuids) ->
+					m.chai.expect(uuids.one).to.not.equal(uuids.two)
+					m.chai.expect(uuids.two).to.not.equal(uuids.three)
+					m.chai.expect(uuids.three).to.not.equal(uuids.one)
+				.nodeify(done)
 
 		describe '.register()', ->
 


### PR DESCRIPTION
The change is propagated from resin-io/resin-register-device. See
commit:

	https://github.com/resin-io/resin-register-device/commit/e1858f00d8659f5ae8fcb07f6dcd245a217e1bcc