### PR TITLE
Make getPubNubKeys and getMixpanelToken private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased][unreleased]
+
+### Changed
+
+- Make `resin.models.config.getPubNubKeys()` and `resin.models.config.getMixpanelToken()` private.
+
 ## [2.8.0] - 2015-09-24
 
 ### Added

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -66,8 +66,6 @@ If you feel something is missing, not clear or could be improved, please don't h
       * [.download(parameters)](#resin.models.os.download) ⇒ <code>Promise</code>
     * [.config](#resin.models.config) : <code>object</code>
       * [.getAll()](#resin.models.config.getAll) ⇒ <code>Promise</code>
-      * [.getPubNubKeys()](#resin.models.config.getPubNubKeys) ⇒ <code>Promise</code>
-      * [.getMixpanelToken()](#resin.models.config.getMixpanelToken) ⇒ <code>Promise</code>
       * [.getDeviceTypes()](#resin.models.config.getDeviceTypes) ⇒ <code>Promise</code>
       * [.getDeviceOptions(deviceType)](#resin.models.config.getDeviceOptions) ⇒ <code>Promise</code>
   * [.auth](#resin.auth) : <code>object</code>
@@ -149,8 +147,6 @@ If you feel something is missing, not clear or could be improved, please don't h
     * [.download(parameters)](#resin.models.os.download) ⇒ <code>Promise</code>
   * [.config](#resin.models.config) : <code>object</code>
     * [.getAll()](#resin.models.config.getAll) ⇒ <code>Promise</code>
-    * [.getPubNubKeys()](#resin.models.config.getPubNubKeys) ⇒ <code>Promise</code>
-    * [.getMixpanelToken()](#resin.models.config.getMixpanelToken) ⇒ <code>Promise</code>
     * [.getDeviceTypes()](#resin.models.config.getDeviceTypes) ⇒ <code>Promise</code>
     * [.getDeviceOptions(deviceType)](#resin.models.config.getDeviceOptions) ⇒ <code>Promise</code>
 
@@ -1249,8 +1245,6 @@ resin.models.os.download parameters, (error, stream) ->
 
 * [.config](#resin.models.config) : <code>object</code>
   * [.getAll()](#resin.models.config.getAll) ⇒ <code>Promise</code>
-  * [.getPubNubKeys()](#resin.models.config.getPubNubKeys) ⇒ <code>Promise</code>
-  * [.getMixpanelToken()](#resin.models.config.getMixpanelToken) ⇒ <code>Promise</code>
   * [.getDeviceTypes()](#resin.models.config.getDeviceTypes) ⇒ <code>Promise</code>
   * [.getDeviceOptions(deviceType)](#resin.models.config.getDeviceOptions) ⇒ <code>Promise</code>
 
@@ -1270,42 +1264,6 @@ resin.models.config.getAll().then (config) ->
 resin.models.config.getAll (error, config) ->
 	throw error if error?
 	console.log(config)
-```
-<a name="resin.models.config.getPubNubKeys"></a>
-##### config.getPubNubKeys() ⇒ <code>Promise</code>
-**Kind**: static method of <code>[config](#resin.models.config)</code>  
-**Summary**: Get PubNub keys  
-**Access:** public  
-**Fulfil**: <code>Object</code> - pubnub keys  
-**Example**  
-```js
-resin.models.config.getPubNubKeys().then (pubnubKeys) ->
-	console.log(pubnubKeys.subscribe_key)
-	console.log(pubnubKeys.publish_key)
-```
-**Example**  
-```js
-resin.models.config.getPubNubKeys (error, pubnubKeys) ->
-	throw error if error?
-	console.log(pubnubKeys.subscribe_key)
-	console.log(pubnubKeys.publish_key)
-```
-<a name="resin.models.config.getMixpanelToken"></a>
-##### config.getMixpanelToken() ⇒ <code>Promise</code>
-**Kind**: static method of <code>[config](#resin.models.config)</code>  
-**Summary**: Get Mixpanel token  
-**Access:** public  
-**Fulfil**: <code>String</code> - Mixpanel token  
-**Example**  
-```js
-resin.models.config.getMixpanelToken().then (mixpanelToken) ->
-	console.log(mixpanelToken)
-```
-**Example**  
-```js
-resin.models.config.getMixpanelToken (error, mixpanelToken) ->
-	throw error if error?
-	console.log(mixpanelToken)
 ```
 <a name="resin.models.config.getDeviceTypes"></a>
 ##### config.getDeviceTypes() ⇒ <code>Promise</code>

--- a/build/models/config.js
+++ b/build/models/config.js
@@ -64,7 +64,7 @@ THE SOFTWARE.
   /**
    * @summary Get PubNub keys
    * @name getPubNubKeys
-   * @public
+   * @private
    * @function
    * @memberof resin.models.config
    *
@@ -95,7 +95,7 @@ THE SOFTWARE.
   /**
    * @summary Get Mixpanel token
    * @name getMixpanelToken
-   * @public
+   * @private
    * @function
    * @memberof resin.models.config
    *

--- a/lib/models/config.coffee
+++ b/lib/models/config.coffee
@@ -55,7 +55,7 @@ exports.getAll = (callback) ->
 ###*
 # @summary Get PubNub keys
 # @name getPubNubKeys
-# @public
+# @private
 # @function
 # @memberof resin.models.config
 #
@@ -82,7 +82,7 @@ exports.getPubNubKeys = (callback) ->
 ###*
 # @summary Get Mixpanel token
 # @name getMixpanelToken
-# @public
+# @private
 # @function
 # @memberof resin.models.config
 #


### PR DESCRIPTION
Currently this functions are publicly exposed in the documentation.
Given that there is no need for a user to interact with them directly,
we mark them as *private*.

Notice that the functions still exist and are available to the client,
but they don't appear in the public generated documentation.