### PR TITLE
Support searching a device type slug by a slug

### DIFF
--- a/build/models/device.js
+++ b/build/models/device.js
@@ -581,10 +581,14 @@ THE SOFTWARE.
 
   exports.getDeviceSlug = function(deviceTypeName, callback) {
     return configModel.getDeviceTypes().then(function(deviceTypes) {
-      var deviceTypeFound;
-      deviceTypeFound = _.findWhere(deviceTypes, {
+      var deviceTypeFound, foundByName, foundBySlug;
+      foundByName = _.findWhere(deviceTypes, {
         name: deviceTypeName
       });
+      foundBySlug = _.findWhere(deviceTypes, {
+        slug: deviceTypeName
+      });
+      deviceTypeFound = foundByName || foundBySlug;
       return deviceTypeFound != null ? deviceTypeFound.slug : void 0;
     }).nodeify(callback);
   };

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -506,7 +506,10 @@ exports.getDisplayName = (deviceTypeSlug, callback) ->
 ###
 exports.getDeviceSlug = (deviceTypeName, callback) ->
 	configModel.getDeviceTypes().then (deviceTypes) ->
-		deviceTypeFound = _.findWhere(deviceTypes, name: deviceTypeName)
+		foundByName = _.findWhere(deviceTypes, name: deviceTypeName)
+		foundBySlug = _.findWhere(deviceTypes, slug: deviceTypeName)
+		deviceTypeFound = foundByName or foundBySlug
+
 		return deviceTypeFound?.slug
 	.nodeify(callback)
 

--- a/tests/models/device.spec.coffee
+++ b/tests/models/device.spec.coffee
@@ -668,6 +668,12 @@ describe 'Device Model:', ->
 						promise = device.getDeviceSlug('Foo Bar')
 						m.chai.expect(promise).to.eventually.be.undefined
 
+				describe 'given a slug', ->
+
+					it 'should return the device that matches the slug', ->
+						promise = device.getDeviceSlug('raspberry-pi')
+						m.chai.expect(promise).to.eventually.equal('raspberry-pi')
+
 		describe '.getSupportedDeviceTypes()', ->
 
 			describe 'given device types', ->


### PR DESCRIPTION
Passing a slug to `resin.models.device.getDeviceSlug()` returns
undefined. A more natural behaviour would be to return the same slug if it is already recognised.