### PR TITLE
Require an email instead of username in auth

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1352,7 +1352,7 @@ resin.auth.whoami (error, username) ->
 <a name="resin.auth.authenticate"></a>
 #### auth.authenticate(credentials) ⇒ <code>Promise</code>
 You should use [module:resin.auth.login](module:resin.auth.login) when possible,
-as it takes care of saving the token and username as well.
+as it takes care of saving the token and email as well.
 
 Notice that if `credentials` contains extra keys, they'll be discarted
 by the server automatically.
@@ -1364,8 +1364,8 @@ by the server automatically.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| credentials | <code>Object</code> | in the form of username, password |
-| credentials.username | <code>String</code> | the username |
+| credentials | <code>Object</code> | in the form of email, password |
+| credentials.email | <code>String</code> | the email |
 | credentials.password | <code>String</code> | the password |
 
 **Example**  
@@ -1389,8 +1389,8 @@ If the login is successful, the token is persisted between sessions.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| credentials | <code>Object</code> | in the form of username, password |
-| credentials.username | <code>String</code> | the username |
+| credentials | <code>Object</code> | in the form of email, password |
+| credentials.email | <code>String</code> | the email |
 | credentials.password | <code>String</code> | the password |
 
 **Example**  

--- a/build/auth.js
+++ b/build/auth.js
@@ -75,13 +75,13 @@ THE SOFTWARE.
    * @memberof resin.auth
    *
    * @description You should use {@link module:resin.auth.login} when possible,
-   * as it takes care of saving the token and username as well.
+   * as it takes care of saving the token and email as well.
    *
    * Notice that if `credentials` contains extra keys, they'll be discarted
    * by the server automatically.
    *
-   * @param {Object} credentials - in the form of username, password
-   * @param {String} credentials.username - the username
+   * @param {Object} credentials - in the form of email, password
+   * @param {String} credentials.email - the email
    * @param {String} credentials.password - the password
    *
    * @fulfil {String} - session token
@@ -101,7 +101,10 @@ THE SOFTWARE.
     return request.send({
       method: 'POST',
       url: '/login_',
-      body: credentials,
+      body: {
+        username: credentials.email,
+        password: credentials.password
+      },
       refreshToken: false
     }).get('body').nodeify(callback);
   };
@@ -116,8 +119,8 @@ THE SOFTWARE.
    *
    * @description If the login is successful, the token is persisted between sessions.
    *
-   * @param {Object} credentials - in the form of username, password
-   * @param {String} credentials.username - the username
+   * @param {Object} credentials - in the form of email, password
+   * @param {String} credentials.email - the email
    * @param {String} credentials.password - the password
    *
    * @returns {Promise}

--- a/lib/auth.coffee
+++ b/lib/auth.coffee
@@ -65,13 +65,13 @@ exports.whoami = (callback) ->
 # @memberof resin.auth
 #
 # @description You should use {@link module:resin.auth.login} when possible,
-# as it takes care of saving the token and username as well.
+# as it takes care of saving the token and email as well.
 #
 # Notice that if `credentials` contains extra keys, they'll be discarted
 # by the server automatically.
 #
-# @param {Object} credentials - in the form of username, password
-# @param {String} credentials.username - the username
+# @param {Object} credentials - in the form of email, password
+# @param {String} credentials.email - the email
 # @param {String} credentials.password - the password
 #
 # @fulfil {String} - session token
@@ -90,7 +90,9 @@ exports.authenticate = (credentials, callback) ->
 	request.send
 		method: 'POST'
 		url: '/login_'
-		body: credentials
+		body:
+			username: credentials.email
+			password: credentials.password
 		refreshToken: false
 	.get('body')
 	.nodeify(callback)
@@ -104,8 +106,8 @@ exports.authenticate = (credentials, callback) ->
 #
 # @description If the login is successful, the token is persisted between sessions.
 #
-# @param {Object} credentials - in the form of username, password
-# @param {String} credentials.username - the username
+# @param {Object} credentials - in the form of email, password
+# @param {String} credentials.email - the email
 # @param {String} credentials.password - the password
 #
 # @returns {Promise}

--- a/tests/auth.spec.coffee
+++ b/tests/auth.spec.coffee
@@ -55,7 +55,7 @@ describe 'Auth:', ->
 
 				it 'should eventually return a token', ->
 					promise = auth.authenticate
-						username: 'foo'
+						email: 'foo'
 						password: 'bar'
 
 					m.chai.expect(promise).to.eventually.equal(johnDoeFixture.token)
@@ -72,7 +72,7 @@ describe 'Auth:', ->
 
 				it 'should be rejected', ->
 					promise = auth.authenticate
-						username: 'foo'
+						email: 'foo'
 						password: 'bar'
 
 					m.chai.expect(promise).to.be.rejectedWith('Unauthorized')
@@ -91,7 +91,7 @@ describe 'Auth:', ->
 
 				it 'should be rejected', ->
 					promise = auth.login
-						username: 'foo'
+						email: 'foo'
 						password: 'bar'
 
 					m.chai.expect(promise).to.be.rejectedWith('Unauthorized')
@@ -115,7 +115,7 @@ describe 'Auth:', ->
 						m.chai.expect(auth.getToken()).to.be.rejectedWith(errors.ResinNotLoggedIn)
 
 						auth.login
-							username: 'foo'
+							email: 'foo'
 							password: 'bar'
 						.then ->
 							m.chai.expect(auth.getToken()).to.eventually.equal(johnDoeFixture.token)
@@ -130,7 +130,7 @@ describe 'Auth:', ->
 						m.chai.expect(auth.getToken()).to.eventually.equal(janeDoeFixture.token)
 
 						auth.login
-							username: 'foo'
+							email: 'foo'
 							password: 'bar'
 						.then ->
 							m.chai.expect(auth.getToken()).to.eventually.equal(johnDoeFixture.token)
@@ -371,7 +371,7 @@ describe 'Auth:', ->
 
 					it 'should eventually return a token', ->
 						promise = auth.authenticate
-							username: 'foo'
+							email: 'foo'
 							password: 'bar'
 
 						m.chai.expect(promise).to.eventually.equal(johnDoeFixture.token)


### PR DESCRIPTION
In fact, both a username and an email will do fine in the `username`
field. To encourage users to use their email for login, we just rename
the `username` property to `email`.