### PR TITLE
Simplify resin.auth.2fa.isPassed()

### DIFF
--- a/build/2fa.js
+++ b/build/2fa.js
@@ -85,13 +85,8 @@ THE SOFTWARE.
    */
 
   exports.isPassed = function(callback) {
-    return exports.isEnabled().then(function(isEnabled) {
-      if (!isEnabled) {
-        return true;
-      }
-      return token.getProperty('twoFactorRequired').then(function(twoFactorRequired) {
-        return !twoFactorRequired;
-      });
+    return token.getProperty('twoFactorRequired').then(function(twoFactorRequired) {
+      return !twoFactorRequired;
     }).nodeify(callback);
   };
 

--- a/lib/2fa.coffee
+++ b/lib/2fa.coffee
@@ -75,13 +75,8 @@ exports.isEnabled = (callback) ->
 # 		console.log('2FA challenge passed')
 ###
 exports.isPassed = (callback) ->
-	exports.isEnabled().then (isEnabled) ->
-
-		# Users without 2FA always passed
-		return true if not isEnabled
-
-		token.getProperty('twoFactorRequired').then (twoFactorRequired) ->
-			return not twoFactorRequired
+	token.getProperty('twoFactorRequired').then (twoFactorRequired) ->
+		return not twoFactorRequired
 	.nodeify(callback)
 
 ###*


### PR DESCRIPTION
We return `true` if 2FA is not enabled, which means that
`twoFactorRequired` is `undefined`.

Later on, we attempt to negate the value of `twoFactorRequired`.

Notice that `!undefined === true`, therefore if 2FA is not enabled, the
second check will return `true` already.