### PR TITLE
Disallow moving a device to an incompatible application

### DIFF
--- a/build/models/device.js
+++ b/build/models/device.js
@@ -537,22 +537,23 @@ THE SOFTWARE.
    */
 
   exports.move = function(uuid, application, callback) {
-    return exports.has(uuid).then(function(hasDevice) {
-      if (!hasDevice) {
-        throw new errors.ResinDeviceNotFound(uuid);
+    return Promise.props({
+      device: exports.get(uuid),
+      application: applicationModel.get(application)
+    }).then(function(results) {
+      if (results.device.device_type !== results.application.device_type) {
+        throw new Error("Incompatible application: " + application);
       }
-      return applicationModel.get(application).get('id').then(function(applicationId) {
-        return pine.patch({
-          resource: 'device',
-          body: {
-            application: applicationId
-          },
-          options: {
-            filter: {
-              uuid: uuid
-            }
+      return pine.patch({
+        resource: 'device',
+        body: {
+          application: results.application.id
+        },
+        options: {
+          filter: {
+            uuid: uuid
           }
-        });
+        }
       });
     }).nodeify(callback);
   };

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -471,19 +471,21 @@ exports.note = (uuid, note, callback) ->
 # });
 ###
 exports.move = (uuid, application, callback) ->
-	exports.has(uuid).then (hasDevice) ->
+	Promise.props
+		device: exports.get(uuid)
+		application: applicationModel.get(application)
+	.then (results) ->
 
-		if not hasDevice
-			throw new errors.ResinDeviceNotFound(uuid)
+		if results.device.device_type isnt results.application.device_type
+			throw new Error("Incompatible application: #{application}")
 
-		applicationModel.get(application).get('id').then (applicationId) ->
-			return pine.patch
-				resource: 'device'
-				body:
-					application: applicationId
-				options:
-					filter:
-						uuid: uuid
+		return pine.patch
+			resource: 'device'
+			body:
+				application: results.application.id
+			options:
+				filter:
+					uuid: uuid
 
 	.nodeify(callback)
 


### PR DESCRIPTION
Currently, `resin.models.device.move()` allows you to move a device to
an application that doesn't contain the same device type.