### PR TITLE
Upgrade resin-device-logs to v2.0.0

### DIFF
--- a/build/logs.js
+++ b/build/logs.js
@@ -75,12 +75,11 @@ THE SOFTWARE.
    */
 
   exports.subscribe = function(uuid, callback) {
-    return deviceModel.has(uuid).then(function(hasDevice) {
-      if (!hasDevice) {
-        throw new errors.ResinDeviceNotFound(uuid);
-      }
-    }).then(configModel.getPubNubKeys).then(function(pubNubKeys) {
-      return logs.subscribe(pubNubKeys, uuid);
+    return Promise.props({
+      device: deviceModel.get(uuid),
+      pubNubKeys: configModel.getPubNubKeys()
+    }).then(function(results) {
+      return logs.subscribe(results.pubNubKeys, results.device);
     }).nodeify(callback);
   };
 
@@ -114,12 +113,11 @@ THE SOFTWARE.
    */
 
   exports.history = function(uuid, callback) {
-    return deviceModel.has(uuid).then(function(hasDevice) {
-      if (!hasDevice) {
-        throw new errors.ResinDeviceNotFound(uuid);
-      }
-    }).then(configModel.getPubNubKeys).then(function(pubNubKeys) {
-      return logs.history(pubNubKeys, uuid);
+    return Promise.props({
+      device: deviceModel.get(uuid),
+      pubNubKeys: configModel.getPubNubKeys()
+    }).then(function(results) {
+      return logs.history(results.pubNubKeys, results.device);
     }).nodeify(callback);
   };
 

--- a/lib/logs.coffee
+++ b/lib/logs.coffee
@@ -65,11 +65,11 @@ deviceModel = require('./models/device')
 # });
 ###
 exports.subscribe = (uuid, callback) ->
-	deviceModel.has(uuid).then (hasDevice) ->
-		if not hasDevice
-			throw new errors.ResinDeviceNotFound(uuid)
-	.then(configModel.getPubNubKeys).then (pubNubKeys) ->
-		return logs.subscribe(pubNubKeys, uuid)
+	Promise.props
+		device: deviceModel.get(uuid)
+		pubNubKeys: configModel.getPubNubKeys()
+	.then (results) ->
+		return logs.subscribe(results.pubNubKeys, results.device)
 	.nodeify(callback)
 
 ###*
@@ -100,9 +100,9 @@ exports.subscribe = (uuid, callback) ->
 # });
 ###
 exports.history = (uuid, callback) ->
-	deviceModel.has(uuid).then (hasDevice) ->
-		if not hasDevice
-			throw new errors.ResinDeviceNotFound(uuid)
-	.then(configModel.getPubNubKeys).then (pubNubKeys) ->
-		return logs.history(pubNubKeys, uuid)
+	Promise.props
+		device: deviceModel.get(uuid)
+		pubNubKeys: configModel.getPubNubKeys()
+	.then (results) ->
+		return logs.history(results.pubNubKeys, results.device)
 	.nodeify(callback)

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "bluebird": "^2.9.32",
     "lodash": "~3.9.1",
-    "resin-device-logs": "^1.0.0",
+    "resin-device-logs": "^2.0.1",
     "resin-errors": "^2.0.0",
     "resin-pine": "^1.3.1",
     "resin-register-device": "^2.0.0",

--- a/tests/logs.spec.coffee
+++ b/tests/logs.spec.coffee
@@ -24,11 +24,11 @@ describe 'Logs:', ->
 			describe 'given the device does not exist', ->
 
 				beforeEach ->
-					@deviceHasStub = m.sinon.stub(device, 'has')
-					@deviceHasStub.returns(Promise.resolve(false))
+					@deviceGetStub = m.sinon.stub(device, 'get')
+					@deviceGetStub.returns(Promise.reject(new errors.ResinDeviceNotFound('asdf')))
 
 				afterEach ->
-					@deviceHasStub.restore()
+					@deviceGetStub.restore()
 
 				it 'should be rejected', ->
 					promise = logs.subscribe('1234')
@@ -37,11 +37,11 @@ describe 'Logs:', ->
 		describe 'given the device exists', ->
 
 			beforeEach ->
-				@deviceHasStub = m.sinon.stub(device, 'has')
-				@deviceHasStub.returns(Promise.resolve(true))
+				@deviceGetStub = m.sinon.stub(device, 'get')
+				@deviceGetStub.returns(Promise.resolve(uuid: 'asdf'))
 
 			afterEach ->
-				@deviceHasStub.restore()
+				@deviceGetStub.restore()
 
 			describe 'given no pubnub keys', ->
 
@@ -72,11 +72,11 @@ describe 'Logs:', ->
 			describe 'given the device does not exist', ->
 
 				beforeEach ->
-					@deviceHasStub = m.sinon.stub(device, 'has')
-					@deviceHasStub.returns(Promise.resolve(false))
+					@deviceGetStub = m.sinon.stub(device, 'get')
+					@deviceGetStub.returns(Promise.reject(new errors.ResinDeviceNotFound('asdf')))
 
 				afterEach ->
-					@deviceHasStub.restore()
+					@deviceGetStub.restore()
 
 				it 'should be rejected', ->
 					promise = logs.history('1234')
@@ -85,11 +85,11 @@ describe 'Logs:', ->
 		describe 'given the device exists', ->
 
 			beforeEach ->
-				@deviceHasStub = m.sinon.stub(device, 'has')
-				@deviceHasStub.returns(Promise.resolve(true))
+				@deviceGetStub = m.sinon.stub(device, 'get')
+				@deviceGetStub.returns(Promise.resolve(uuid: 'asdf'))
 
 			afterEach ->
-				@deviceHasStub.restore()
+				@deviceGetStub.restore()
 
 			describe 'given no pubnub keys', ->
 


### PR DESCRIPTION
This new version contains necessary functionality to get logs from
recently provisioned devices.