### PR TITLE
Ensure environment variable values are strings

### DIFF
--- a/lib/models/environment-variables.coffee
+++ b/lib/models/environment-variables.coffee
@@ -77,7 +77,7 @@ exports.create = (applicationName, name, value, callback) ->
 			resource: 'environment_variable'
 			body:
 				name: name
-				value: value
+				value: String(value)
 				application: applicationId
 	.nodeify(callback)
 
@@ -235,7 +235,7 @@ exports.device.create = (uuid, name, value, callback) ->
 			body:
 				device: device.id
 				env_var_name: name
-				value: value
+				value: String(value)
 	.nodeify(callback)
 
 ###*

--- a/tests/integration.coffee
+++ b/tests/integration.coffee
@@ -627,6 +627,15 @@ describe 'SDK Integration Tests', ->
 							m.chai.expect(envs[0].value).to.equal('vim')
 						.nodeify(done)
 
+					it 'should be able to create a numeric non resin variable', (done) ->
+						resin.models.environmentVariables.create(@application.app_name, 'EDITOR', 1).then =>
+							resin.models.environmentVariables.getAllByApplication(@application.app_name)
+						.then (envs) ->
+							m.chai.expect(envs).to.have.length(1)
+							m.chai.expect(envs[0].name).to.equal('EDITOR')
+							m.chai.expect(envs[0].value).to.equal('1')
+						.nodeify(done)
+
 					it 'should not allow creating a resin variable', ->
 						promise = resin.models.environmentVariables.create(@application.app_name, 'RESIN_API_KEY', 'secret')
 						m.chai.expect(promise).to.be.rejectedWith('Environment variables RESIN, USER, and any beginning with RESIN_ are reserved.')
@@ -922,6 +931,15 @@ describe 'SDK Integration Tests', ->
 							m.chai.expect(envs).to.have.length(1)
 							m.chai.expect(envs[0].name).to.equal('EDITOR')
 							m.chai.expect(envs[0].value).to.equal('vim')
+						.nodeify(done)
+
+					it 'should be able to create a numeric non resin variable', (done) ->
+						resin.models.environmentVariables.device.create(@device.uuid, 'EDITOR', 1).then =>
+							resin.models.environmentVariables.device.getAll(@device.uuid)
+						.then (envs) ->
+							m.chai.expect(envs).to.have.length(1)
+							m.chai.expect(envs[0].name).to.equal('EDITOR')
+							m.chai.expect(envs[0].value).to.equal('1')
 						.nodeify(done)
 
 					it 'should not allow creating a resin variable', ->


### PR DESCRIPTION
Otherwise, doing:

```
resin env add KEY 1 --application appname
```

Fails with the following error message:

```
ResinRequestError: Request error: "value" is not a string: 1
``````

See https://github.com/resin-io/resin-cli/pull/297