### PR TITLE
Fix error when fetching a device with a number uuid

### DIFF
--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -124,6 +124,10 @@ exports.getAllByApplication = (name, callback) ->
 # });
 ###
 exports.get = (uuid, callback) ->
+
+	# Make sure uuid is a string
+	uuid = String(uuid)
+
 	return pine.get
 		resource: 'device'
 		options:

--- a/tests/integration.coffee
+++ b/tests/integration.coffee
@@ -977,6 +977,28 @@ describe 'SDK Integration Tests', ->
 								m.chai.expect(envs).to.have.length(0)
 							.nodeify(done)
 
+
+		describe 'given a single application with a device id whose shorter uuid is only numbers', ->
+
+			beforeEach (done) ->
+				resin.models.application.create('TestApp', 'raspberry-pi').then (application) =>
+					@application = application
+
+					uuid = '1234567aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+					resin.models.device.register(application.app_name, uuid)
+				.then (device) =>
+					@device = device
+				.nodeify(done)
+
+			describe 'Device Model', ->
+
+				describe 'resin.models.device.get()', ->
+
+					it 'should return the device given the number shorter uuid', (done) ->
+						resin.models.device.get(1234567).then (device) =>
+							m.chai.expect(device.id).to.equal(@device.id)
+						.nodeify(done)
+
 		describe 'given a single application with two offline devices that share the same uuid root', ->
 
 			beforeEach (done) ->


### PR DESCRIPTION
Take a device uuid like this:

	728046334d1fcbb956ae240381d68ba3283ce8b1a870f512665271134f7a19

Notice the first nine characters are numbers, therefore we expect
something like:

	resin.models.device.get(728046334)

But passing a number directly throws the following error:

	Expected null/string/number/obj/array, got: undefined

on `uuid.length`.