### PR TITLE
Implement resin.models.device.getStatus()

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -47,6 +47,7 @@ If you feel something is missing, not clear or could be improved, please don't h
             * [.getDeviceUrl(uuid)](#resin.models.device.getDeviceUrl) ⇒ <code>Promise</code>
             * [.enableDeviceUrl(uuid)](#resin.models.device.enableDeviceUrl) ⇒ <code>Promise</code>
             * [.disableDeviceUrl(uuid)](#resin.models.device.disableDeviceUrl) ⇒ <code>Promise</code>
+            * [.getStatus(uuid)](#resin.models.device.getStatus) ⇒ <code>Promise</code>
         * [.key](#resin.models.key) : <code>object</code>
             * [.getAll()](#resin.models.key.getAll) ⇒ <code>Promise</code>
             * [.get(id)](#resin.models.key.get) ⇒ <code>Promise</code>
@@ -134,6 +135,7 @@ If you feel something is missing, not clear or could be improved, please don't h
         * [.getDeviceUrl(uuid)](#resin.models.device.getDeviceUrl) ⇒ <code>Promise</code>
         * [.enableDeviceUrl(uuid)](#resin.models.device.enableDeviceUrl) ⇒ <code>Promise</code>
         * [.disableDeviceUrl(uuid)](#resin.models.device.disableDeviceUrl) ⇒ <code>Promise</code>
+        * [.getStatus(uuid)](#resin.models.device.getStatus) ⇒ <code>Promise</code>
     * [.key](#resin.models.key) : <code>object</code>
         * [.getAll()](#resin.models.key.getAll) ⇒ <code>Promise</code>
         * [.get(id)](#resin.models.key.get) ⇒ <code>Promise</code>
@@ -403,6 +405,7 @@ resin.models.application.getApiKey('MyApp', function(error, apiKey) {
     * [.getDeviceUrl(uuid)](#resin.models.device.getDeviceUrl) ⇒ <code>Promise</code>
     * [.enableDeviceUrl(uuid)](#resin.models.device.enableDeviceUrl) ⇒ <code>Promise</code>
     * [.disableDeviceUrl(uuid)](#resin.models.device.disableDeviceUrl) ⇒ <code>Promise</code>
+    * [.getStatus(uuid)](#resin.models.device.getStatus) ⇒ <code>Promise</code>
 
 <a name="resin.models.device.getAll"></a>
 ##### device.getAll() ⇒ <code>Promise</code>
@@ -1004,6 +1007,30 @@ resin.models.device.disableDeviceUrl('7cf02a6');
 ```js
 resin.models.device.disableDeviceUrl('7cf02a6', function(error) {
 	if (error) throw error;
+});
+```
+<a name="resin.models.device.getStatus"></a>
+##### device.getStatus(uuid) ⇒ <code>Promise</code>
+**Kind**: static method of <code>[device](#resin.models.device)</code>  
+**Summary**: Get the status of a device  
+**Access:** public  
+**Fulfil**: <code>String</code> - device statud  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| uuid | <code>String</code> | device uuid |
+
+**Example**  
+```js
+resin.models.device.getStatus('7cf02a6').then(function(status) {
+	console.log(status);
+});
+```
+**Example**  
+```js
+resin.models.device.getStatus('7cf02a6', function(error, status) {
+	if (error) throw error;
+	console.log(status);
 });
 ```
 <a name="resin.models.key"></a>

--- a/build/models/device.js
+++ b/build/models/device.js
@@ -16,7 +16,7 @@ limitations under the License.
  */
 
 (function() {
-  var Promise, _, applicationModel, auth, configModel, crypto, errors, pine, registerDevice, request;
+  var Promise, _, applicationModel, auth, configModel, crypto, deviceStatus, errors, pine, registerDevice, request;
 
   Promise = require('bluebird');
 
@@ -31,6 +31,8 @@ limitations under the License.
   request = require('resin-request');
 
   registerDevice = require('resin-register-device');
+
+  deviceStatus = require('resin-device-status');
 
   configModel = require('./config');
 
@@ -986,6 +988,36 @@ limitations under the License.
           }
         }
       });
+    }).nodeify(callback);
+  };
+
+
+  /**
+   * @summary Get the status of a device
+   * @name getStatus
+   * @public
+   * @function
+   * @memberof resin.models.device
+   *
+   * @param {String} uuid - device uuid
+   * @fulfil {String} - device statud
+   * @returns {Promise}
+   *
+   * @example
+   * resin.models.device.getStatus('7cf02a6').then(function(status) {
+   * 	console.log(status);
+   * });
+   *
+   * @example
+   * resin.models.device.getStatus('7cf02a6', function(error, status) {
+   * 	if (error) throw error;
+   * 	console.log(status);
+   * });
+   */
+
+  exports.getStatus = function(uuid, callback) {
+    return Promise["try"](function() {
+      return deviceStatus.getStatus(uuid).key;
     }).nodeify(callback);
   };
 

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -21,6 +21,7 @@ pine = require('resin-pine')
 errors = require('resin-errors')
 request = require('resin-request')
 registerDevice = require('resin-register-device')
+deviceStatus = require('resin-device-status')
 configModel = require('./config')
 applicationModel = require('./application')
 auth = require('../auth')
@@ -876,4 +877,31 @@ exports.disableDeviceUrl = (uuid, callback) ->
 			options:
 				filter:
 					uuid: uuid
+	.nodeify(callback)
+
+###*
+# @summary Get the status of a device
+# @name getStatus
+# @public
+# @function
+# @memberof resin.models.device
+#
+# @param {String} uuid - device uuid
+# @fulfil {String} - device statud
+# @returns {Promise}
+#
+# @example
+# resin.models.device.getStatus('7cf02a6').then(function(status) {
+# 	console.log(status);
+# });
+#
+# @example
+# resin.models.device.getStatus('7cf02a6', function(error, status) {
+# 	if (error) throw error;
+# 	console.log(status);
+# });
+###
+exports.getStatus = (uuid, callback) ->
+	Promise.try ->
+		return deviceStatus.getStatus(uuid).key
 	.nodeify(callback)

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "lodash": "~3.9.1",
     "resin-device-logs": "^2.0.1",
     "resin-errors": "^2.2.0",
+    "resin-device-status": "^1.0.0",
     "resin-pine": "^1.3.1",
     "resin-register-device": "^2.0.0",
     "resin-request": "^4.0.1",

--- a/tests/integration.coffee
+++ b/tests/integration.coffee
@@ -910,6 +910,12 @@ describe 'SDK Integration Tests', ->
 								m.chai.expect(promise).to.eventually.be.false
 							.nodeify(done)
 
+				describe 'resin.models.device.getStatus()', ->
+
+					it 'should return the correct status slug', ->
+						promise = resin.models.device.getStatus(@device.uuid)
+						m.chai.expect(promise).to.eventually.equal('offline')
+
 			describe 'Environment Variables Model', ->
 
 				describe 'resin.models.environmentVariables.device.getAll()', ->


### PR DESCRIPTION
This function makes use of [resin-device-status](https://github.com/resin-io/resin-device-status)
to return a slug representing the current device status, based on the
properties of the device object.

Only the device status slug is returned, instead of an object containing
both the slug and the display name to simplify the interface and return
a unique identifier that the user can then choose to show with the
display name of their preference.

The function, despite being synchronous, was converted into a promise to
be consistent with the rest of the API, and to avoid potential breaking
changes by this function needing to be async in the future.

Fixes: https://github.com/resin-io/resin-sdk/issues/183