### PR TITLE
Decouple SDK from environment settings

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -90,8 +90,9 @@ If you feel something is missing, not clear or could be improved, please don't h
         * [.subscribe(uuid)](#resin.logs.subscribe) ⇒ <code>Promise</code>
         * [.history(uuid)](#resin.logs.history) ⇒ <code>Promise</code>
     * [.settings](#resin.settings) : <code>object</code>
-        * [.get([key])](#resin.settings.get) ⇒ <code>Promise</code>
-        * [.getAll()](#resin.settings.getAll) ⇒ <code>Promise</code>
+        * [.set([key], [value])](#resin.settings.set)
+        * [.get([key])](#resin.settings.get) ⇒ <code>\*</code>
+        * [.getAll()](#resin.settings.getAll) ⇒ <code>Object</code>
 
 <a name="resin.models"></a>
 ### resin.models : <code>object</code>
@@ -1902,15 +1903,38 @@ resin.logs.history('7cf02a6', function(error, lines) {
 **Kind**: static namespace of <code>[resin](#resin)</code>  
 
 * [.settings](#resin.settings) : <code>object</code>
-    * [.get([key])](#resin.settings.get) ⇒ <code>Promise</code>
-    * [.getAll()](#resin.settings.getAll) ⇒ <code>Promise</code>
+    * [.set([key], [value])](#resin.settings.set)
+    * [.get([key])](#resin.settings.get) ⇒ <code>\*</code>
+    * [.getAll()](#resin.settings.getAll) ⇒ <code>Object</code>
 
+<a name="resin.settings.set"></a>
+#### settings.set([key], [value])
+**Kind**: static method of <code>[settings](#resin.settings)</code>  
+**Summary**: Set settings  
+**Access:** public  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| [key] | <code>String</code> &#124; <code>Object</code> | setting key |
+| [value] | <code>\*</code> | setting value |
+
+**Example**  
+```js
+resin.settings.set('resinUrl', 'resin.io');
+```
+**Example**  
+```js
+resin.settings.set({
+  resinUrl: 'resin.io',
+  apiUrl: 'https://api.resin.io'
+});
+```
 <a name="resin.settings.get"></a>
-#### settings.get([key]) ⇒ <code>Promise</code>
+#### settings.get([key]) ⇒ <code>\*</code>
 **Kind**: static method of <code>[settings](#resin.settings)</code>  
 **Summary**: Get a single setting  
+**Returns**: <code>\*</code> - - setting value  
 **Access:** public  
-**Fulfil**: <code>\*</code> - setting value  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1918,33 +1942,15 @@ resin.logs.history('7cf02a6', function(error, lines) {
 
 **Example**  
 ```js
-resin.settings.get('apiUrl').then(function(apiUrl) {
-	console.log(apiUrl);
-});
-```
-**Example**  
-```js
-resin.settings.get('apiUrl', function(error, apiUrl) {
-	if (error) throw error;
-	console.log(apiUrl);
-});
+var apiUrl = resin.settings.get('apiUrl');
 ```
 <a name="resin.settings.getAll"></a>
-#### settings.getAll() ⇒ <code>Promise</code>
+#### settings.getAll() ⇒ <code>Object</code>
 **Kind**: static method of <code>[settings](#resin.settings)</code>  
 **Summary**: Get all settings  
+**Returns**: <code>Object</code> - - settings  
 **Access:** public  
-**Fulfil**: <code>Object</code> - settings  
 **Example**  
 ```js
-resin.settings.getAll().then(function(settings) {
-	console.log(settings);
-});
-```
-**Example**  
-```js
-resin.settings.getAll(function(error, settings) {
-	if (error) throw error;
-	console.log(settings);
-});
+var settings = resin.settings.getAll();
 ```

--- a/build/2fa.js
+++ b/build/2fa.js
@@ -16,11 +16,13 @@ limitations under the License.
  */
 
 (function() {
-  var request, token;
+  var request, settings, token;
 
   token = require('resin-token');
 
   request = require('resin-request');
+
+  settings = require('./settings');
 
 
   /**
@@ -113,6 +115,7 @@ limitations under the License.
   exports.challenge = function(code, callback) {
     return request.send({
       method: 'POST',
+      baseUrl: settings.get('apiUrl'),
       url: '/auth/totp/verify',
       body: {
         code: code

--- a/build/auth.js
+++ b/build/auth.js
@@ -16,13 +16,15 @@ limitations under the License.
  */
 
 (function() {
-  var errors, request, token;
+  var errors, request, settings, token;
 
   errors = require('resin-errors');
 
   request = require('resin-request');
 
   token = require('resin-token');
+
+  settings = require('./settings');
 
 
   /**
@@ -106,6 +108,7 @@ limitations under the License.
   exports.authenticate = function(credentials, callback) {
     return request.send({
       method: 'POST',
+      baseUrl: settings.get('apiUrl'),
       url: '/login_',
       body: {
         username: credentials.email,
@@ -205,6 +208,7 @@ limitations under the License.
   exports.isLoggedIn = function(callback) {
     return request.send({
       method: 'GET',
+      baseUrl: settings.get('apiUrl'),
       url: '/whoami'
     })["return"](true)["catch"](function() {
       return false;
@@ -375,6 +379,7 @@ limitations under the License.
     }
     return request.send({
       method: 'POST',
+      baseUrl: settings.get('apiUrl'),
       url: '/user/register',
       body: credentials
     }).get('body').nodeify(callback);

--- a/build/models/application.js
+++ b/build/models/application.js
@@ -16,7 +16,7 @@ limitations under the License.
  */
 
 (function() {
-  var _, deviceModel, errors, pine, request, token;
+  var _, deviceModel, errors, pine, request, settings, token;
 
   _ = require('lodash');
 
@@ -27,6 +27,8 @@ limitations under the License.
   token = require('resin-token');
 
   pine = require('resin-pine');
+
+  settings = require('../settings');
 
   deviceModel = require('./device');
 
@@ -307,6 +309,7 @@ limitations under the License.
     return exports.get(name).then(function(application) {
       return request.send({
         method: 'POST',
+        baseUrl: settings.get('apiUrl'),
         url: "/application/" + application.id + "/restart"
       });
     })["return"](void 0).nodeify(callback);
@@ -340,6 +343,7 @@ limitations under the License.
     return exports.get(name).then(function(application) {
       return request.send({
         method: 'POST',
+        baseUrl: settings.get('apiUrl'),
         url: "/application/" + application.id + "/generate-api-key"
       });
     }).get('body').nodeify(callback);

--- a/build/models/application.js
+++ b/build/models/application.js
@@ -58,6 +58,7 @@ limitations under the License.
   exports.getAll = function(callback) {
     return token.getUserId().then(function(userId) {
       return pine.get({
+        apiPrefix: settings.get('pineUrl'),
         resource: 'application',
         options: {
           orderby: 'app_name asc',
@@ -103,6 +104,7 @@ limitations under the License.
 
   exports.get = function(name, callback) {
     return pine.get({
+      apiPrefix: settings.get('pineUrl'),
       resource: 'application',
       options: {
         filter: {
@@ -201,6 +203,7 @@ limitations under the License.
 
   exports.getById = function(id, callback) {
     return pine.get({
+      apiPrefix: settings.get('pineUrl'),
       resource: 'application',
       id: id
     }).tap(function(application) {
@@ -243,6 +246,7 @@ limitations under the License.
       }
     }).then(function(deviceSlug) {
       return pine.post({
+        apiPrefix: settings.get('pineUrl'),
         resource: 'application',
         body: {
           app_name: name,
@@ -275,6 +279,7 @@ limitations under the License.
   exports.remove = function(name, callback) {
     return exports.get(name).then(function() {
       return pine["delete"]({
+        apiPrefix: settings.get('pineUrl'),
         resource: 'application',
         options: {
           filter: {

--- a/build/models/config.js
+++ b/build/models/config.js
@@ -16,11 +16,13 @@ limitations under the License.
  */
 
 (function() {
-  var _, deviceModel, request;
+  var _, deviceModel, request, settings;
 
   _ = require('lodash');
 
   request = require('resin-request');
+
+  settings = require('../settings');
 
   deviceModel = require('./device');
 
@@ -50,6 +52,7 @@ limitations under the License.
   exports.getAll = function(callback) {
     return request.send({
       method: 'GET',
+      baseUrl: settings.get('apiUrl'),
       url: '/config'
     }).get('body').then(function(body) {
       body.deviceTypes = _.map(body.deviceTypes, function(deviceType) {

--- a/build/models/device.js
+++ b/build/models/device.js
@@ -850,6 +850,7 @@ limitations under the License.
       application: applicationModel.get(applicationName)
     }).then(function(results) {
       return registerDevice.register(pine, {
+        apiPrefix: settings.get('pineUrl'),
         userId: results.userId,
         applicationId: results.application.id,
         deviceType: results.application.device_type,

--- a/build/models/device.js
+++ b/build/models/device.js
@@ -16,7 +16,7 @@ limitations under the License.
  */
 
 (function() {
-  var Promise, _, applicationModel, auth, configModel, crypto, deviceStatus, errors, pine, registerDevice, request;
+  var Promise, _, applicationModel, auth, configModel, crypto, deviceStatus, errors, pine, registerDevice, request, settings;
 
   Promise = require('bluebird');
 
@@ -33,6 +33,8 @@ limitations under the License.
   registerDevice = require('resin-register-device');
 
   deviceStatus = require('resin-device-status');
+
+  settings = require('../settings');
 
   configModel = require('./config');
 
@@ -435,6 +437,7 @@ limitations under the License.
       }
       return request.send({
         method: 'POST',
+        baseUrl: settings.get('apiUrl'),
         url: '/blink',
         body: {
           uuid: uuid
@@ -593,6 +596,7 @@ limitations under the License.
     return exports.get(uuid).then(function(device) {
       return request.send({
         method: 'POST',
+        baseUrl: settings.get('apiUrl'),
         url: "/device/" + device.id + "/restart"
       });
     }).get('body').nodeify(callback);

--- a/build/models/device.js
+++ b/build/models/device.js
@@ -67,6 +67,7 @@ limitations under the License.
 
   exports.getAll = function(callback) {
     return pine.get({
+      apiPrefix: settings.get('pineUrl'),
       resource: 'device',
       options: {
         expand: 'application',
@@ -108,6 +109,7 @@ limitations under the License.
         throw new errors.ResinApplicationNotFound(name);
       }
       return pine.get({
+        apiPrefix: settings.get('pineUrl'),
         resource: 'device',
         options: {
           filter: {
@@ -152,6 +154,7 @@ limitations under the License.
   exports.get = function(uuid, callback) {
     uuid = String(uuid);
     return pine.get({
+      apiPrefix: settings.get('pineUrl'),
       resource: 'device',
       options: {
         expand: 'application',
@@ -205,6 +208,7 @@ limitations under the License.
 
   exports.getByName = function(name, callback) {
     return pine.get({
+      apiPrefix: settings.get('pineUrl'),
       resource: 'device',
       options: {
         expand: 'application',
@@ -400,6 +404,7 @@ limitations under the License.
   exports.remove = function(uuid, callback) {
     return exports.get(uuid).then(function() {
       return pine["delete"]({
+        apiPrefix: settings.get('pineUrl'),
         resource: 'device',
         options: {
           filter: {
@@ -474,6 +479,7 @@ limitations under the License.
         throw new errors.ResinDeviceNotFound(uuid);
       }
       return pine.patch({
+        apiPrefix: settings.get('pineUrl'),
         resource: 'device',
         body: {
           name: newName
@@ -515,6 +521,7 @@ limitations under the License.
         throw new errors.ResinDeviceNotFound(uuid);
       }
       return pine.patch({
+        apiPrefix: settings.get('pineUrl'),
         resource: 'device',
         body: {
           note: note
@@ -559,6 +566,7 @@ limitations under the License.
         throw new Error("Incompatible application: " + application);
       }
       return pine.patch({
+        apiPrefix: settings.get('pineUrl'),
         resource: 'device',
         body: {
           application: results.application.id
@@ -937,6 +945,7 @@ limitations under the License.
         throw new errors.ResinDeviceNotFound(uuid);
       }
       return pine.patch({
+        apiPrefix: settings.get('pineUrl'),
         resource: 'device',
         body: {
           is_web_accessible: true
@@ -976,6 +985,7 @@ limitations under the License.
         throw new errors.ResinDeviceNotFound(uuid);
       }
       return pine.patch({
+        apiPrefix: settings.get('pineUrl'),
         resource: 'device',
         body: {
           is_web_accessible: false

--- a/build/models/environment-variables.js
+++ b/build/models/environment-variables.js
@@ -16,9 +16,11 @@ limitations under the License.
  */
 
 (function() {
-  var applicationModel, deviceModel, pine;
+  var applicationModel, deviceModel, pine, settings;
 
   pine = require('resin-pine');
+
+  settings = require('../settings');
 
   deviceModel = require('./device');
 
@@ -51,6 +53,7 @@ limitations under the License.
   exports.getAllByApplication = function(applicationName, callback) {
     return applicationModel.get(applicationName).get('id').then(function(applicationId) {
       return pine.get({
+        apiPrefix: settings.get('pineUrl'),
         resource: 'environment_variable',
         options: {
           filter: {
@@ -88,6 +91,7 @@ limitations under the License.
   exports.create = function(applicationName, name, value, callback) {
     return applicationModel.get(applicationName).get('id').then(function(applicationId) {
       return pine.post({
+        apiPrefix: settings.get('pineUrl'),
         resource: 'environment_variable',
         body: {
           name: name,
@@ -122,6 +126,7 @@ limitations under the License.
 
   exports.update = function(id, value, callback) {
     return pine.patch({
+      apiPrefix: settings.get('pineUrl'),
       resource: 'environment_variable',
       id: id,
       body: {
@@ -152,6 +157,7 @@ limitations under the License.
 
   exports.remove = function(id, callback) {
     return pine["delete"]({
+      apiPrefix: settings.get('pineUrl'),
       resource: 'environment_variable',
       id: id
     }).nodeify(callback);
@@ -220,6 +226,7 @@ limitations under the License.
   exports.device.getAll = function(uuid, callback) {
     return deviceModel.get(uuid).then(function(device) {
       return pine.get({
+        apiPrefix: settings.get('pineUrl'),
         resource: 'device_environment_variable',
         options: {
           filter: {
@@ -264,6 +271,7 @@ limitations under the License.
   exports.device.create = function(uuid, name, value, callback) {
     return deviceModel.get(uuid).then(function(device) {
       return pine.post({
+        apiPrefix: settings.get('pineUrl'),
         resource: 'device_environment_variable',
         body: {
           device: device.id,
@@ -298,6 +306,7 @@ limitations under the License.
 
   exports.device.update = function(id, value, callback) {
     return pine.patch({
+      apiPrefix: settings.get('pineUrl'),
       resource: 'device_environment_variable',
       id: id,
       body: {
@@ -328,6 +337,7 @@ limitations under the License.
 
   exports.device.remove = function(id, callback) {
     return pine["delete"]({
+      apiPrefix: settings.get('pineUrl'),
       resource: 'device_environment_variable',
       id: id
     }).nodeify(callback);

--- a/build/models/key.js
+++ b/build/models/key.js
@@ -16,13 +16,15 @@ limitations under the License.
  */
 
 (function() {
-  var _, auth, errors, pine;
+  var _, auth, errors, pine, settings;
 
   _ = require('lodash');
 
   errors = require('resin-errors');
 
   pine = require('resin-pine');
+
+  settings = require('../settings');
 
   auth = require('../auth');
 
@@ -51,6 +53,7 @@ limitations under the License.
 
   exports.getAll = function(callback) {
     return pine.get({
+      apiPrefix: settings.get('pineUrl'),
       resource: 'user__has__public_key'
     }).nodeify(callback);
   };
@@ -81,6 +84,7 @@ limitations under the License.
 
   exports.get = function(id, callback) {
     return pine.get({
+      apiPrefix: settings.get('pineUrl'),
       resource: 'user__has__public_key',
       id: id
     }).tap(function(key) {
@@ -112,6 +116,7 @@ limitations under the License.
 
   exports.remove = function(id, callback) {
     return pine["delete"]({
+      apiPrefix: settings.get('pineUrl'),
       resource: 'user__has__public_key',
       id: id
     }).nodeify(callback);
@@ -147,6 +152,7 @@ limitations under the License.
     key = key.trim();
     return auth.getUserId().then(function(userId) {
       return pine.post({
+        apiPrefix: settings.get('pineUrl'),
         resource: 'user__has__public_key',
         body: {
           title: title,

--- a/build/models/os.js
+++ b/build/models/os.js
@@ -24,7 +24,7 @@ limitations under the License.
 
   errors = require('resin-errors');
 
-  settings = require('resin-settings-client');
+  settings = require('../settings');
 
   getImageMakerUrl = function(deviceType) {
     var imageMakerUrl;

--- a/build/settings.js
+++ b/build/settings.js
@@ -44,6 +44,14 @@ limitations under the License.
     },
 
     /**
+    	 * @property {Function} pineUrl - Resin.io Pine API url
+    	 * @memberof settings
+     */
+    pineUrl: function() {
+      return ((typeof this.apiUrl === "function" ? this.apiUrl() : void 0) || this.apiUrl) + "/ewa/";
+    },
+
+    /**
     	 * @property {Function} vpnUrl - Resin.io VPN url
     	 * @memberof settings
      */

--- a/build/settings.js
+++ b/build/settings.js
@@ -30,12 +30,6 @@ limitations under the License.
   settings = {
 
     /**
-    	 * @property {Number} tokenRefreshInterval - token refresh interval
-    	 * @memberof settings
-     */
-    tokenRefreshInterval: 1 * 1000 * 60 * 60,
-
-    /**
     	 * @property {String} resinUrl - Resin.io url
     	 * @memberof settings
      */

--- a/build/settings.js
+++ b/build/settings.js
@@ -16,11 +16,123 @@ limitations under the License.
  */
 
 (function() {
-  var Promise, settings;
+  var _, cachedSettings, evaluateSettings, settings;
 
-  Promise = require('bluebird');
+  _ = require('lodash');
 
-  settings = require('resin-settings-client');
+
+  /**
+   * @summary Default settings
+   * @namespace settings
+   * @private
+   */
+
+  settings = {
+
+    /**
+    	 * @property {Number} tokenRefreshInterval - token refresh interval
+    	 * @memberof settings
+     */
+    tokenRefreshInterval: 1 * 1000 * 60 * 60,
+
+    /**
+    	 * @property {String} resinUrl - Resin.io url
+    	 * @memberof settings
+     */
+    resinUrl: 'resin.io',
+
+    /**
+    	 * @property {Function} apiUrl - Resin.io API url
+    	 * @memberof settings
+     */
+    apiUrl: function() {
+      return "https://api." + this.resinUrl;
+    },
+
+    /**
+    	 * @property {Function} vpnUrl - Resin.io VPN url
+    	 * @memberof settings
+     */
+    vpnUrl: function() {
+      return "vpn." + this.resinUrl;
+    },
+
+    /**
+    	 * @property {Function} registryUrl - Resin.io Registry url
+    	 * @memberof settings
+     */
+    registryUrl: function() {
+      return "registry." + this.resinUrl;
+    },
+
+    /**
+    	 * @property {Function} imageMakerUrl - Resin.io Image Maker url
+    	 * @memberof settings
+     */
+    imageMakerUrl: function() {
+      return "https://img." + this.resinUrl;
+    },
+
+    /**
+    	 * @property {Function} deltaUrl - Resin.io Delta url
+    	 * @memberof settings
+     */
+    deltaUrl: function() {
+      return "https://delta." + this.resinUrl;
+    },
+
+    /**
+    	 * @property {Function} dashboardUrl - Resin.io dashboard url
+    	 * @memberof settings
+     */
+    dashboardUrl: function() {
+      return "https://dashboard." + this.resinUrl;
+    }
+  };
+
+  evaluateSettings = function() {
+    return _.chain(settings).mapValues(function(value, key) {
+      value = _.get(settings, key);
+      if (_.isFunction(value)) {
+        value = value.call(settings);
+      }
+      return value;
+    }).omit(function(value) {
+      return _.isUndefined(value) || _.isNull(value);
+    }).value();
+  };
+
+  cachedSettings = evaluateSettings();
+
+
+  /**
+   * @summary Set settings
+   * @name set
+   * @function
+   * @public
+   * @memberof resin.settings
+   *
+   * @param {(String|Object)} [key] - setting key
+   * @param {*} [value] - setting value
+   *
+   * @example
+   * resin.settings.set('resinUrl', 'resin.io');
+   *
+   * @example
+   * resin.settings.set({
+   *   resinUrl: 'resin.io',
+   *   apiUrl: 'https://api.resin.io'
+   * });
+   */
+
+  exports.set = function(key, value) {
+    if (_.isPlainObject(key) && (value == null)) {
+      _.assign(settings, key);
+    } else {
+      _.set(settings, key, value);
+    }
+    return cachedSettings = evaluateSettings();
+  };
 
 
   /**
@@ -31,25 +143,14 @@ limitations under the License.
    * @memberof resin.settings
    *
    * @param {String} [key] - setting key
-   * @fulfil {*} - setting value
-   * @returns {Promise}
+   * @returns {*} - setting value
    *
    * @example
-   * resin.settings.get('apiUrl').then(function(apiUrl) {
-   * 	console.log(apiUrl);
-   * });
-   *
-   * @example
-   * resin.settings.get('apiUrl', function(error, apiUrl) {
-   * 	if (error) throw error;
-   * 	console.log(apiUrl);
-   * });
+   * var apiUrl = resin.settings.get('apiUrl');
    */
 
-  exports.get = function(key, callback) {
-    return Promise["try"](function() {
-      return settings.get(key);
-    }).nodeify(callback);
+  exports.get = function(key) {
+    return _.get(cachedSettings, key);
   };
 
 
@@ -60,25 +161,14 @@ limitations under the License.
    * @public
    * @memberof resin.settings
    *
-   * @fulfil {Object} - settings
-   * @returns {Promise}
+   * @returns {Object} - settings
    *
    * @example
-   * resin.settings.getAll().then(function(settings) {
-   * 	console.log(settings);
-   * });
-   *
-   * @example
-   * resin.settings.getAll(function(error, settings) {
-   * 	if (error) throw error;
-   * 	console.log(settings);
-   * });
+   * var settings = resin.settings.getAll();
    */
 
-  exports.getAll = function(callback) {
-    return Promise["try"](function() {
-      return settings.getAll();
-    }).nodeify(callback);
+  exports.getAll = function() {
+    return _.clone(cachedSettings);
   };
 
 }).call(this);

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -14,6 +14,7 @@ OPTIONS =
 		coffee: [ 'lib/**/*.coffee', 'tests/**/*.coffee', 'gulpfile.coffee' ]
 		app: 'lib/**/*.coffee'
 		integration: 'tests/integration.coffee'
+		tests: 'tests/**/*.spec.coffee'
 		javascript: 'build/**/*.js'
 	directories:
 		doc: 'doc/'
@@ -24,11 +25,19 @@ gulp.task 'coffee', ->
 		.pipe(coffee()).on('error', gutil.log)
 		.pipe(gulp.dest(OPTIONS.directories.build))
 
-gulp.task 'test', ->
+gulp.task 'test:e2e', [ 'test:spec' ], ->
 	gulp.src(OPTIONS.files.integration, read: false)
 		.pipe(mocha({
 			reporter: 'spec'
 		}))
+
+gulp.task 'test:spec', ->
+	gulp.src(OPTIONS.files.tests, read: false)
+		.pipe(mocha({
+			reporter: 'progress'
+		}))
+
+gulp.task('test', [ 'test:spec', 'test:e2e' ])
 
 gulp.task 'lint', ->
 	gulp.src(OPTIONS.files.coffee)
@@ -40,7 +49,8 @@ gulp.task 'lint', ->
 gulp.task 'build', (callback) ->
 	runSequence([
 		'lint'
+		'test:spec'
 	], [ 'coffee' ], callback)
 
 gulp.task 'watch', [ 'build' ], ->
-	gulp.watch([ OPTIONS.files.coffee ], [ 'lint' ])
+	gulp.watch([ OPTIONS.files.coffee ], [ 'lint', 'coffee', 'test:spec' ])

--- a/lib/2fa.coffee
+++ b/lib/2fa.coffee
@@ -16,6 +16,7 @@ limitations under the License.
 
 token = require('resin-token')
 request = require('resin-request')
+settings = require('./settings')
 
 ###*
 # @summary Check if two factor authentication is enabled
@@ -100,6 +101,7 @@ exports.isPassed = (callback) ->
 exports.challenge = (code, callback) ->
 	request.send
 		method: 'POST'
+		baseUrl: settings.get('apiUrl')
 		url: '/auth/totp/verify'
 		body: { code }
 	.get('body')

--- a/lib/auth.coffee
+++ b/lib/auth.coffee
@@ -17,6 +17,7 @@ limitations under the License.
 errors = require('resin-errors')
 request = require('resin-request')
 token = require('resin-token')
+settings = require('./settings')
 
 ###*
 # @namespace resin.auth.twoFactor
@@ -93,6 +94,7 @@ exports.whoami = (callback) ->
 exports.authenticate = (credentials, callback) ->
 	request.send
 		method: 'POST'
+		baseUrl: settings.get('apiUrl')
 		url: '/login_'
 		body:
 			username: credentials.email
@@ -185,6 +187,7 @@ exports.loginWithToken = (authToken, callback) ->
 exports.isLoggedIn = (callback) ->
 	request.send
 		method: 'GET'
+		baseUrl: settings.get('apiUrl')
 		url: '/whoami'
 	.return(true)
 	.catch ->
@@ -332,6 +335,7 @@ exports.logout = (callback) ->
 exports.register = (credentials = {}, callback) ->
 	request.send
 		method: 'POST'
+		baseUrl: settings.get('apiUrl')
 		url: '/user/register'
 		body: credentials
 	.get('body')

--- a/lib/models/application.coffee
+++ b/lib/models/application.coffee
@@ -46,6 +46,7 @@ deviceModel = require('./device')
 exports.getAll = (callback) ->
 	token.getUserId().then (userId) ->
 		return pine.get
+			apiPrefix: settings.get('pineUrl')
 			resource: 'application'
 			options:
 				orderby: 'app_name asc'
@@ -86,6 +87,7 @@ exports.getAll = (callback) ->
 ###
 exports.get = (name, callback) ->
 	return pine.get
+		apiPrefix: settings.get('pineUrl')
 		resource: 'application'
 		options:
 			filter:
@@ -175,6 +177,7 @@ exports.hasAny = (callback) ->
 ###
 exports.getById = (id, callback) ->
 	return pine.get
+		apiPrefix: settings.get('pineUrl')
 		resource: 'application'
 		id: id
 	.tap (application) ->
@@ -215,6 +218,7 @@ exports.create = (name, deviceType, callback) ->
 
 	.then (deviceSlug) ->
 		return pine.post
+			apiPrefix: settings.get('pineUrl')
 			resource: 'application'
 			body:
 				app_name: name
@@ -242,6 +246,7 @@ exports.create = (name, deviceType, callback) ->
 exports.remove = (name, callback) ->
 	exports.get(name).then ->
 		return pine.delete
+			apiPrefix: settings.get('pineUrl')
 			resource: 'application'
 			options:
 				filter:

--- a/lib/models/application.coffee
+++ b/lib/models/application.coffee
@@ -19,6 +19,7 @@ errors = require('resin-errors')
 request = require('resin-request')
 token = require('resin-token')
 pine = require('resin-pine')
+settings = require('../settings')
 deviceModel = require('./device')
 
 ###*
@@ -269,6 +270,7 @@ exports.restart = (name, callback) ->
 	exports.get(name).then (application) ->
 		return request.send
 			method: 'POST'
+			baseUrl: settings.get('apiUrl')
 			url: "/application/#{application.id}/restart"
 	.return(undefined)
 	.nodeify(callback)
@@ -299,6 +301,7 @@ exports.getApiKey = (name, callback) ->
 	exports.get(name).then (application) ->
 		return request.send
 			method: 'POST'
+			baseUrl: settings.get('apiUrl')
 			url: "/application/#{application.id}/generate-api-key"
 	.get('body')
 	.nodeify(callback)

--- a/lib/models/config.coffee
+++ b/lib/models/config.coffee
@@ -16,6 +16,7 @@ limitations under the License.
 
 _ = require('lodash')
 request = require('resin-request')
+settings = require('../settings')
 deviceModel = require('./device')
 
 ###*
@@ -42,6 +43,7 @@ deviceModel = require('./device')
 exports.getAll = (callback) ->
 	request.send
 		method: 'GET'
+		baseUrl: settings.get('apiUrl')
 		url: '/config'
 	.get('body')
 	.then (body) ->

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -772,6 +772,7 @@ exports.register = (applicationName, uuid, callback) ->
 	.then (results) ->
 
 		return registerDevice.register pine,
+			apiPrefix: settings.get('pineUrl')
 			userId: results.userId
 			applicationId: results.application.id
 			deviceType: results.application.device_type

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -22,6 +22,7 @@ errors = require('resin-errors')
 request = require('resin-request')
 registerDevice = require('resin-register-device')
 deviceStatus = require('resin-device-status')
+settings = require('../settings')
 configModel = require('./config')
 applicationModel = require('./application')
 auth = require('../auth')
@@ -390,6 +391,7 @@ exports.identify = (uuid, callback) ->
 
 		return request.send
 			method: 'POST'
+			baseUrl: settings.get('apiUrl')
 			url: '/blink'
 			body:
 				uuid: uuid
@@ -528,6 +530,7 @@ exports.restart = (uuid, callback) ->
 	exports.get(uuid).then (device) ->
 		return request.send
 			method: 'POST'
+			baseUrl: settings.get('apiUrl')
 			url: "/device/#{device.id}/restart"
 	.get('body')
 	.nodeify(callback)

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -50,6 +50,7 @@ auth = require('../auth')
 ###
 exports.getAll = (callback) ->
 	return pine.get
+		apiPrefix: settings.get('pineUrl')
 		resource: 'device'
 		options:
 			expand: 'application'
@@ -89,6 +90,7 @@ exports.getAllByApplication = (name, callback) ->
 			throw new errors.ResinApplicationNotFound(name)
 
 		return pine.get
+			apiPrefix: settings.get('pineUrl')
 			resource: 'device'
 			options:
 				filter:
@@ -131,6 +133,7 @@ exports.get = (uuid, callback) ->
 	uuid = String(uuid)
 
 	return pine.get
+		apiPrefix: settings.get('pineUrl')
 		resource: 'device'
 		options:
 			expand: 'application'
@@ -184,6 +187,7 @@ exports.get = (uuid, callback) ->
 ###
 exports.getByName = (name, callback) ->
 	return pine.get
+		apiPrefix: settings.get('pineUrl')
 		resource: 'device'
 		options:
 			expand: 'application'
@@ -359,6 +363,7 @@ exports.getLocalIPAddresses = (uuid, callback) ->
 exports.remove = (uuid, callback) ->
 	exports.get(uuid).then ->
 		return pine.delete
+			apiPrefix: settings.get('pineUrl')
 			resource: 'device'
 			options:
 				filter:
@@ -425,6 +430,7 @@ exports.rename = (uuid, newName, callback) ->
 			throw new errors.ResinDeviceNotFound(uuid)
 
 		return pine.patch
+			apiPrefix: settings.get('pineUrl')
 			resource: 'device'
 			body:
 				name: newName
@@ -460,6 +466,7 @@ exports.note = (uuid, note, callback) ->
 			throw new errors.ResinDeviceNotFound(uuid)
 
 		return pine.patch
+			apiPrefix: settings.get('pineUrl')
 			resource: 'device'
 			body:
 				note: note
@@ -499,6 +506,7 @@ exports.move = (uuid, application, callback) ->
 			throw new Error("Incompatible application: #{application}")
 
 		return pine.patch
+			apiPrefix: settings.get('pineUrl')
 			resource: 'device'
 			body:
 				application: results.application.id
@@ -851,6 +859,7 @@ exports.enableDeviceUrl = (uuid, callback) ->
 			throw new errors.ResinDeviceNotFound(uuid)
 
 		return pine.patch
+			apiPrefix: settings.get('pineUrl')
 			resource: 'device'
 			body:
 				is_web_accessible: true
@@ -884,6 +893,7 @@ exports.disableDeviceUrl = (uuid, callback) ->
 			throw new errors.ResinDeviceNotFound(uuid)
 
 		return pine.patch
+			apiPrefix: settings.get('pineUrl')
 			resource: 'device'
 			body:
 				is_web_accessible: false

--- a/lib/models/environment-variables.coffee
+++ b/lib/models/environment-variables.coffee
@@ -15,6 +15,7 @@ limitations under the License.
 ###
 
 pine = require('resin-pine')
+settings = require('../settings')
 deviceModel = require('./device')
 applicationModel = require('./application')
 
@@ -43,6 +44,7 @@ applicationModel = require('./application')
 exports.getAllByApplication = (applicationName, callback) ->
 	applicationModel.get(applicationName).get('id').then (applicationId) ->
 		return pine.get
+			apiPrefix: settings.get('pineUrl')
 			resource: 'environment_variable'
 			options:
 				filter:
@@ -74,6 +76,7 @@ exports.getAllByApplication = (applicationName, callback) ->
 exports.create = (applicationName, name, value, callback) ->
 	applicationModel.get(applicationName).get('id').then (applicationId) ->
 		return pine.post
+			apiPrefix: settings.get('pineUrl')
 			resource: 'environment_variable'
 			body:
 				name: name
@@ -103,6 +106,7 @@ exports.create = (applicationName, name, value, callback) ->
 ###
 exports.update = (id, value, callback) ->
 	return pine.patch
+		apiPrefix: settings.get('pineUrl')
 		resource: 'environment_variable'
 		id: id
 		body:
@@ -129,6 +133,7 @@ exports.update = (id, value, callback) ->
 ###
 exports.remove = (id, callback) ->
 	return pine.delete
+		apiPrefix: settings.get('pineUrl')
 		resource: 'environment_variable'
 		id: id
 	.nodeify(callback)
@@ -189,6 +194,7 @@ exports.device = {}
 exports.device.getAll = (uuid, callback) ->
 	deviceModel.get(uuid).then (device) ->
 		return pine.get
+			apiPrefix: settings.get('pineUrl')
 			resource: 'device_environment_variable'
 			options:
 				filter:
@@ -231,6 +237,7 @@ exports.device.getAll = (uuid, callback) ->
 exports.device.create = (uuid, name, value, callback) ->
 	deviceModel.get(uuid).then (device) ->
 		return pine.post
+			apiPrefix: settings.get('pineUrl')
 			resource: 'device_environment_variable'
 			body:
 				device: device.id
@@ -260,6 +267,7 @@ exports.device.create = (uuid, name, value, callback) ->
 ###
 exports.device.update = (id, value, callback) ->
 	return pine.patch
+		apiPrefix: settings.get('pineUrl')
 		resource: 'device_environment_variable'
 		id: id
 		body:
@@ -286,6 +294,7 @@ exports.device.update = (id, value, callback) ->
 ###
 exports.device.remove = (id, callback) ->
 	return pine.delete
+		apiPrefix: settings.get('pineUrl')
 		resource: 'device_environment_variable'
 		id: id
 	.nodeify(callback)

--- a/lib/models/key.coffee
+++ b/lib/models/key.coffee
@@ -17,6 +17,7 @@ limitations under the License.
 _ = require('lodash')
 errors = require('resin-errors')
 pine = require('resin-pine')
+settings = require('../settings')
 auth = require('../auth')
 
 ###*
@@ -42,6 +43,7 @@ auth = require('../auth')
 ###
 exports.getAll = (callback) ->
 	return pine.get
+		apiPrefix: settings.get('pineUrl')
 		resource: 'user__has__public_key'
 	.nodeify(callback)
 
@@ -69,6 +71,7 @@ exports.getAll = (callback) ->
 ###
 exports.get = (id, callback) ->
 	return pine.get
+		apiPrefix: settings.get('pineUrl')
 		resource: 'user__has__public_key'
 		id: id
 	.tap (key) ->
@@ -96,6 +99,7 @@ exports.get = (id, callback) ->
 ###
 exports.remove = (id, callback) ->
 	return pine.delete
+		apiPrefix: settings.get('pineUrl')
 		resource: 'user__has__public_key'
 		id: id
 	.nodeify(callback)
@@ -131,6 +135,7 @@ exports.create = (title, key, callback) ->
 
 	auth.getUserId().then (userId) ->
 		return pine.post
+			apiPrefix: settings.get('pineUrl')
 			resource: 'user__has__public_key'
 			body:
 				title: title

--- a/lib/models/os.coffee
+++ b/lib/models/os.coffee
@@ -17,7 +17,7 @@ limitations under the License.
 url = require('url')
 request = require('resin-request')
 errors = require('resin-errors')
-settings = require('resin-settings-client')
+settings = require('../settings')
 
 getImageMakerUrl = (deviceType) ->
 	imageMakerUrl = settings.get('imageMakerUrl')

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -37,6 +37,13 @@ settings =
 		return "https://api.#{@resinUrl}"
 
 	###*
+	# @property {Function} pineUrl - Resin.io Pine API url
+	# @memberof settings
+	###
+	pineUrl: ->
+		return "#{@apiUrl?() or @apiUrl}/ewa/"
+
+	###*
 	# @property {Function} vpnUrl - Resin.io VPN url
 	# @memberof settings
 	###

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -14,8 +14,115 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ###
 
-Promise = require('bluebird')
-settings = require('resin-settings-client')
+_ = require('lodash')
+
+###*
+# @summary Default settings
+# @namespace settings
+# @private
+###
+settings =
+
+	###*
+	# @property {Number} tokenRefreshInterval - token refresh interval
+	# @memberof settings
+	###
+	tokenRefreshInterval: 1 * 1000 * 60 * 60 # 1 hour in milliseconds
+
+	###*
+	# @property {String} resinUrl - Resin.io url
+	# @memberof settings
+	###
+	resinUrl: 'resin.io'
+
+	###*
+	# @property {Function} apiUrl - Resin.io API url
+	# @memberof settings
+	###
+	apiUrl: ->
+		return "https://api.#{@resinUrl}"
+
+	###*
+	# @property {Function} vpnUrl - Resin.io VPN url
+	# @memberof settings
+	###
+	vpnUrl: ->
+		return "vpn.#{@resinUrl}"
+
+	###*
+	# @property {Function} registryUrl - Resin.io Registry url
+	# @memberof settings
+	###
+	registryUrl: ->
+		return "registry.#{@resinUrl}"
+
+	###*
+	# @property {Function} imageMakerUrl - Resin.io Image Maker url
+	# @memberof settings
+	###
+	imageMakerUrl: ->
+		return "https://img.#{@resinUrl}"
+
+	###*
+	# @property {Function} deltaUrl - Resin.io Delta url
+	# @memberof settings
+	###
+	deltaUrl: ->
+		return "https://delta.#{@resinUrl}"
+
+	###*
+	# @property {Function} dashboardUrl - Resin.io dashboard url
+	# @memberof settings
+	###
+	dashboardUrl: ->
+		return "https://dashboard.#{@resinUrl}"
+
+evaluateSettings = ->
+	return _.chain(settings)
+		.mapValues (value, key) ->
+			value = _.get(settings, key)
+
+			if _.isFunction(value)
+				value = value.call(settings)
+
+			return value
+		.omit (value) ->
+			return _.isUndefined(value) or _.isNull(value)
+		.value()
+
+cachedSettings = evaluateSettings()
+
+###*
+# @summary Set settings
+# @name set
+# @function
+# @public
+# @memberof resin.settings
+#
+# @param {(String|Object)} [key] - setting key
+# @param {*} [value] - setting value
+#
+# @example
+# resin.settings.set('resinUrl', 'resin.io');
+#
+# @example
+# resin.settings.set({
+#   resinUrl: 'resin.io',
+#   apiUrl: 'https://api.resin.io'
+# });
+###
+exports.set = (key, value) ->
+	if _.isPlainObject(key) and not value?
+		_.assign(settings, key)
+	else
+		_.set(settings, key, value)
+
+	# Evaluate all settings functions after a setting
+	# was added/changed for performance reasons,
+	# since .get() and .getAll() only have to query
+	# for primitive properties instead of re-evaluating
+	# setting functions each time.
+	cachedSettings = evaluateSettings()
 
 ###*
 # @summary Get a single setting
@@ -25,24 +132,13 @@ settings = require('resin-settings-client')
 # @memberof resin.settings
 #
 # @param {String} [key] - setting key
-# @fulfil {*} - setting value
-# @returns {Promise}
+# @returns {*} - setting value
 #
 # @example
-# resin.settings.get('apiUrl').then(function(apiUrl) {
-# 	console.log(apiUrl);
-# });
-#
-# @example
-# resin.settings.get('apiUrl', function(error, apiUrl) {
-# 	if (error) throw error;
-# 	console.log(apiUrl);
-# });
+# var apiUrl = resin.settings.get('apiUrl');
 ###
-exports.get = (key, callback) ->
-	Promise.try ->
-		return settings.get(key)
-	.nodeify(callback)
+exports.get = (key) ->
+	return _.get(cachedSettings, key)
 
 ###*
 # @summary Get all settings
@@ -51,21 +147,10 @@ exports.get = (key, callback) ->
 # @public
 # @memberof resin.settings
 #
-# @fulfil {Object} - settings
-# @returns {Promise}
+# @returns {Object} - settings
 #
 # @example
-# resin.settings.getAll().then(function(settings) {
-# 	console.log(settings);
-# });
-#
-# @example
-# resin.settings.getAll(function(error, settings) {
-# 	if (error) throw error;
-# 	console.log(settings);
-# });
+# var settings = resin.settings.getAll();
 ###
-exports.getAll = (callback) ->
-	Promise.try ->
-		return settings.getAll()
-	.nodeify(callback)
+exports.getAll = ->
+	return _.clone(cachedSettings)

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -24,12 +24,6 @@ _ = require('lodash')
 settings =
 
 	###*
-	# @property {Number} tokenRefreshInterval - token refresh interval
-	# @memberof settings
-	###
-	tokenRefreshInterval: 1 * 1000 * 60 * 60 # 1 hour in milliseconds
-
-	###*
 	# @property {String} resinUrl - Resin.io url
 	# @memberof settings
 	###

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "resin-pine": "^1.3.1",
     "resin-register-device": "^2.0.0",
     "resin-request": "^4.0.1",
-    "resin-settings-client": "^3.4.0",
     "resin-token": "^2.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "resin-errors": "^2.2.0",
     "resin-device-status": "^1.0.0",
     "resin-pine": "^1.3.1",
-    "resin-register-device": "^2.0.0",
+    "resin-register-device": "^2.1.0",
     "resin-request": "^4.0.2",
     "resin-token": "^2.4.2"
   }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "resin-device-status": "^1.0.0",
     "resin-pine": "^1.3.1",
     "resin-register-device": "^2.0.0",
-    "resin-request": "^4.0.1",
+    "resin-request": "^4.0.2",
     "resin-token": "^2.4.2"
   }
 }

--- a/tests/integration.coffee
+++ b/tests/integration.coffee
@@ -120,6 +120,7 @@ describe 'SDK Integration Tests', ->
 					.then (userId) ->
 						return resinRequest.send
 							method: 'DELETE'
+							baseUrl: resin.settings.get('apiUrl')
 							url: "/ewa/user(#{userId})"
 						.then(resin.auth.logout)
 					.nodeify (error) ->

--- a/tests/integration.coffee
+++ b/tests/integration.coffee
@@ -19,9 +19,11 @@ reset = ->
 
 		Promise.all [
 			pine.delete
+				apiPrefix: resin.settings.get('pineUrl')
 				resource: 'application'
 
 			pine.delete
+				apiPrefix: resin.settings.get('pineUrl')
 				resource: 'user__has__public_key'
 		]
 

--- a/tests/settings.spec.coffee
+++ b/tests/settings.spec.coffee
@@ -1,0 +1,98 @@
+m = require('mochainon')
+settings = require('../lib/settings')
+
+describe 'Settings', ->
+
+	describe 'given fresh settings', ->
+
+		beforeEach ->
+			for key, value of settings.getAll()
+				settings.set(key, undefined)
+
+		describe '.set()', ->
+
+			it 'should be able to set a single property', ->
+				m.chai.expect(settings.get('foo')).to.be.undefined
+				settings.set('foo', 'bar')
+				m.chai.expect(settings.get('foo')).to.equal('bar')
+
+			it 'should be able to override a setting', ->
+				settings.set('foo', 'bar')
+				m.chai.expect(settings.get('foo')).to.equal('bar')
+				settings.set('foo', 'baz')
+				m.chai.expect(settings.get('foo')).to.equal('baz')
+
+			it 'should be able to set a single property in object mode', ->
+				m.chai.expect(settings.get('foo')).to.be.undefined
+				settings.set(foo: 'bar')
+				m.chai.expect(settings.get('foo')).to.equal('bar')
+
+			it 'should be able to override a setting using object mode', ->
+				settings.set(foo: 'bar')
+				m.chai.expect(settings.get('foo')).to.equal('bar')
+				settings.set(foo: 'baz')
+				m.chai.expect(settings.get('foo')).to.equal('baz')
+
+			it 'should be able to clear a setting', ->
+				settings.set('foo', 'bar')
+				settings.set('foo', undefined)
+				m.chai.expect(settings.get('foo')).to.be.undefined
+
+			it 'should be able to clear a setting using null', ->
+				settings.set('foo', 'bar')
+				settings.set('foo', null)
+				m.chai.expect(settings.get('foo')).to.be.undefined
+
+			it 'should be able to clear a setting in object mode', ->
+				settings.set(foo: 'bar')
+				settings.set(foo: undefined)
+				m.chai.expect(settings.get('foo')).to.be.undefined
+
+			it 'should not clear other settings when using object mode', ->
+				settings.set('foo', 'bar')
+				settings.set('bar', 'baz')
+				settings.set('baz', 'qux')
+				settings.set('qux', 'foo')
+
+				settings.set
+					bar: 'hello'
+					qux: 'world'
+
+				m.chai.expect(settings.getAll()).to.deep.equal
+					foo: 'bar'
+					bar: 'hello'
+					baz: 'qux'
+					qux: 'world'
+
+		describe '.get()', ->
+
+			it 'should be able to get a static setting', ->
+				settings.set('foo', 'bar')
+				m.chai.expect(settings.get('foo')).to.equal('bar')
+
+			it 'should be able to get a dynamic setting', ->
+				settings.set('name', 'John')
+				settings.set 'greeting', ->
+					return "Hello #{@name}!"
+				m.chai.expect(settings.get('greeting')).to.equal('Hello John!')
+
+			it 'should return undefined if the key does not exist', ->
+				m.chai.expect(settings.get('unknown')).to.be.undefined
+
+		describe '.getAll()', ->
+
+			it 'should return an empty object if no settings', ->
+				m.chai.expect(settings.getAll()).to.deep.equal({})
+
+			it 'should be able to get all settings', ->
+				settings.set('foo', 'bar')
+				settings.set('bar', 'baz')
+				m.chai.expect(settings.getAll()).to.deep.equal
+					foo: 'bar'
+					bar: 'baz'
+
+			it 'should make a copy of the object it returns', ->
+				settings.set('foo', 'bar')
+				allSettings = settings.getAll()
+				allSettings.foo = 'baz'
+				m.chai.expect(settings.get('foo')).to.equal('bar')


### PR DESCRIPTION
This is a big, breaking change. Currently the SDK reads settings from the filesystem and environment variables using `resin-settings-client`. With this PR, the SDK only maintain runtime settings set by `resin.settings.set()`.