### PR TITLE
Implement resin.models.device.reboot()

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -36,6 +36,7 @@ If you feel something is missing, not clear or could be improved, please don't h
             * [.note(uuid, note)](#resin.models.device.note) ⇒ <code>Promise</code>
             * [.move(uuid, application)](#resin.models.device.move) ⇒ <code>Promise</code>
             * [.restart(uuid)](#resin.models.device.restart) ⇒ <code>Promise</code>
+            * [.reboot(uuid)](#resin.models.device.reboot) ⇒ <code>Promise</code>
             * [.getDisplayName(deviceTypeSlug)](#resin.models.device.getDisplayName) ⇒ <code>Promise</code>
             * [.getDeviceSlug(deviceTypeName)](#resin.models.device.getDeviceSlug) ⇒ <code>Promise</code>
             * [.getSupportedDeviceTypes()](#resin.models.device.getSupportedDeviceTypes) ⇒ <code>Promise</code>
@@ -124,6 +125,7 @@ If you feel something is missing, not clear or could be improved, please don't h
         * [.note(uuid, note)](#resin.models.device.note) ⇒ <code>Promise</code>
         * [.move(uuid, application)](#resin.models.device.move) ⇒ <code>Promise</code>
         * [.restart(uuid)](#resin.models.device.restart) ⇒ <code>Promise</code>
+        * [.reboot(uuid)](#resin.models.device.reboot) ⇒ <code>Promise</code>
         * [.getDisplayName(deviceTypeSlug)](#resin.models.device.getDisplayName) ⇒ <code>Promise</code>
         * [.getDeviceSlug(deviceTypeName)](#resin.models.device.getDeviceSlug) ⇒ <code>Promise</code>
         * [.getSupportedDeviceTypes()](#resin.models.device.getSupportedDeviceTypes) ⇒ <code>Promise</code>
@@ -394,6 +396,7 @@ resin.models.application.getApiKey('MyApp', function(error, apiKey) {
     * [.note(uuid, note)](#resin.models.device.note) ⇒ <code>Promise</code>
     * [.move(uuid, application)](#resin.models.device.move) ⇒ <code>Promise</code>
     * [.restart(uuid)](#resin.models.device.restart) ⇒ <code>Promise</code>
+    * [.reboot(uuid)](#resin.models.device.reboot) ⇒ <code>Promise</code>
     * [.getDisplayName(deviceTypeSlug)](#resin.models.device.getDisplayName) ⇒ <code>Promise</code>
     * [.getDeviceSlug(deviceTypeName)](#resin.models.device.getDeviceSlug) ⇒ <code>Promise</code>
     * [.getSupportedDeviceTypes()](#resin.models.device.getSupportedDeviceTypes) ⇒ <code>Promise</code>
@@ -734,7 +737,7 @@ the application on the device, but doesn't reboot
 the device itself.
 
 **Kind**: static method of <code>[device](#resin.models.device)</code>  
-**Summary**: Restart device application  
+**Summary**: Restart application on device  
 **Access:** public  
 
 | Param | Type | Description |
@@ -748,6 +751,26 @@ resin.models.device.restart('7cf02a6');
 **Example**  
 ```js
 resin.models.device.restart('7cf02a6', function(error) {
+	if (error) throw error;
+});
+```
+<a name="resin.models.device.reboot"></a>
+##### device.reboot(uuid) ⇒ <code>Promise</code>
+**Kind**: static method of <code>[device](#resin.models.device)</code>  
+**Summary**: Reboot device  
+**Access:** public  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| uuid | <code>String</code> | device uuid |
+
+**Example**  
+```js
+resin.models.device.reboot('7cf02a6');
+```
+**Example**  
+```js
+resin.models.device.reboot('7cf02a6', function(error) {
 	if (error) throw error;
 });
 ```

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -729,8 +729,12 @@ resin.models.device.move('7cf02a6', 'MyApp', function(error) {
 ```
 <a name="resin.models.device.restart"></a>
 ##### device.restart(uuid) ⇒ <code>Promise</code>
+This function restarts the Docker container running
+the application on the device, but doesn't reboot
+the device itself.
+
 **Kind**: static method of <code>[device](#resin.models.device)</code>  
-**Summary**: Restart device  
+**Summary**: Restart device application  
 **Access:** public  
 
 | Param | Type | Description |

--- a/build/models/device.js
+++ b/build/models/device.js
@@ -571,7 +571,7 @@ limitations under the License.
 
 
   /**
-   * @summary Restart device application
+   * @summary Restart application on device
    * @name restart
    * @public
    * @function
@@ -599,6 +599,38 @@ limitations under the License.
       return request.send({
         method: 'POST',
         url: "/device/" + device.id + "/restart"
+      });
+    }).get('body').nodeify(callback);
+  };
+
+
+  /**
+   * @summary Reboot device
+   * @name reboot
+   * @public
+   * @function
+   * @memberof resin.models.device
+   *
+   * @param {String} uuid - device uuid
+   * @returns {Promise}
+   *
+   * @example
+   * resin.models.device.reboot('7cf02a6');
+   *
+   * @example
+   * resin.models.device.reboot('7cf02a6', function(error) {
+   * 	if (error) throw error;
+   * });
+   */
+
+  exports.reboot = function(uuid, callback) {
+    return exports.get(uuid).then(function(device) {
+      return request.send({
+        method: 'POST',
+        url: '/supervisor/v1/reboot',
+        body: {
+          deviceId: device.id
+        }
       });
     }).get('body').nodeify(callback);
   };

--- a/build/models/device.js
+++ b/build/models/device.js
@@ -571,11 +571,16 @@ limitations under the License.
 
 
   /**
-   * @summary Restart device
+   * @summary Restart device application
    * @name restart
    * @public
    * @function
    * @memberof resin.models.device
+   *
+   * @description
+   * This function restarts the Docker container running
+   * the application on the device, but doesn't reboot
+   * the device itself.
    *
    * @param {String} uuid - device uuid
    * @returns {Promise}

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -507,7 +507,7 @@ exports.move = (uuid, application, callback) ->
 	.nodeify(callback)
 
 ###*
-# @summary Restart device application
+# @summary Restart application on device
 # @name restart
 # @public
 # @function
@@ -534,6 +534,34 @@ exports.restart = (uuid, callback) ->
 		return request.send
 			method: 'POST'
 			url: "/device/#{device.id}/restart"
+	.get('body')
+	.nodeify(callback)
+
+###*
+# @summary Reboot device
+# @name reboot
+# @public
+# @function
+# @memberof resin.models.device
+#
+# @param {String} uuid - device uuid
+# @returns {Promise}
+#
+# @example
+# resin.models.device.reboot('7cf02a6');
+#
+# @example
+# resin.models.device.reboot('7cf02a6', function(error) {
+# 	if (error) throw error;
+# });
+###
+exports.reboot = (uuid, callback) ->
+	exports.get(uuid).then (device) ->
+		return request.send
+			method: 'POST'
+			url: '/supervisor/v1/reboot'
+			body:
+				deviceId: device.id
 	.get('body')
 	.nodeify(callback)
 

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -507,11 +507,16 @@ exports.move = (uuid, application, callback) ->
 	.nodeify(callback)
 
 ###*
-# @summary Restart device
+# @summary Restart device application
 # @name restart
 # @public
 # @function
 # @memberof resin.models.device
+#
+# @description
+# This function restarts the Docker container running
+# the application on the device, but doesn't reboot
+# the device itself.
 #
 # @param {String} uuid - device uuid
 # @returns {Promise}


### PR DESCRIPTION
This function allows the user to perform a hard-reboot on the device by
using the Supervisor API:

https://github.com/resin-io/resin-supervisor/blob/master/docs/API.md#post-v1reboot

This function, as well as `resin.models.device.restart()` is not tested in
the integration suite since its not a behaviour we can easily assert on.

Fixes: https://github.com/resin-io/resin-sdk/issues/195

Misc changes:

- Clarify that `device.restart()` restarts the application