### PR TITLE
Make use of baseUrl in all resin-request calls

### DIFF
--- a/build/2fa.js
+++ b/build/2fa.js
@@ -16,11 +16,13 @@ limitations under the License.
  */
 
 (function() {
-  var request, token;
+  var request, settings, token;
 
   token = require('resin-token');
 
   request = require('resin-request');
+
+  settings = require('resin-settings-client');
 
 
   /**
@@ -114,6 +116,7 @@ limitations under the License.
     return request.send({
       method: 'POST',
       url: '/auth/totp/verify',
+      baseUrl: settings.get('apiUrl'),
       body: {
         code: code
       }

--- a/build/auth.js
+++ b/build/auth.js
@@ -16,13 +16,15 @@ limitations under the License.
  */
 
 (function() {
-  var errors, request, token;
+  var errors, request, settings, token;
 
   errors = require('resin-errors');
 
   request = require('resin-request');
 
   token = require('resin-token');
+
+  settings = require('resin-settings-client');
 
 
   /**
@@ -106,6 +108,7 @@ limitations under the License.
   exports.authenticate = function(credentials, callback) {
     return request.send({
       method: 'POST',
+      baseUrl: settings.get('apiUrl'),
       url: '/login_',
       body: {
         username: credentials.email,
@@ -205,7 +208,8 @@ limitations under the License.
   exports.isLoggedIn = function(callback) {
     return request.send({
       method: 'GET',
-      url: '/whoami'
+      url: '/whoami',
+      baseUrl: settings.get('apiUrl')
     })["return"](true)["catch"](function() {
       return false;
     }).nodeify(callback);
@@ -376,6 +380,7 @@ limitations under the License.
     return request.send({
       method: 'POST',
       url: '/user/register',
+      baseUrl: settings.get('apiUrl'),
       body: credentials
     }).get('body').nodeify(callback);
   };

--- a/build/models/application.js
+++ b/build/models/application.js
@@ -16,13 +16,15 @@ limitations under the License.
  */
 
 (function() {
-  var _, deviceModel, errors, pine, request, token;
+  var _, deviceModel, errors, pine, request, settings, token;
 
   _ = require('lodash');
 
   errors = require('resin-errors');
 
   request = require('resin-request');
+
+  settings = require('resin-settings-client');
 
   token = require('resin-token');
 
@@ -307,7 +309,8 @@ limitations under the License.
     return exports.get(name).then(function(application) {
       return request.send({
         method: 'POST',
-        url: "/application/" + application.id + "/restart"
+        url: "/application/" + application.id + "/restart",
+        baseUrl: settings.get('apiUrl')
       });
     })["return"](void 0).nodeify(callback);
   };
@@ -340,7 +343,8 @@ limitations under the License.
     return exports.get(name).then(function(application) {
       return request.send({
         method: 'POST',
-        url: "/application/" + application.id + "/generate-api-key"
+        url: "/application/" + application.id + "/generate-api-key",
+        baseUrl: settings.get('apiUrl')
       });
     }).get('body').nodeify(callback);
   };

--- a/build/models/config.js
+++ b/build/models/config.js
@@ -16,11 +16,13 @@ limitations under the License.
  */
 
 (function() {
-  var _, deviceModel, request;
+  var _, deviceModel, request, settings;
 
   _ = require('lodash');
 
   request = require('resin-request');
+
+  settings = require('resin-settings-client');
 
   deviceModel = require('./device');
 
@@ -50,7 +52,8 @@ limitations under the License.
   exports.getAll = function(callback) {
     return request.send({
       method: 'GET',
-      url: '/config'
+      url: '/config',
+      baseUrl: settings.get('apiUrl')
     }).get('body').then(function(body) {
       body.deviceTypes = _.map(body.deviceTypes, function(deviceType) {
         if (deviceType.state === 'PREVIEW') {

--- a/build/models/device.js
+++ b/build/models/device.js
@@ -16,7 +16,7 @@ limitations under the License.
  */
 
 (function() {
-  var Promise, _, applicationModel, auth, configModel, crypto, deviceStatus, errors, pine, registerDevice, request;
+  var Promise, _, applicationModel, auth, configModel, crypto, deviceStatus, errors, pine, registerDevice, request, settings;
 
   Promise = require('bluebird');
 
@@ -29,6 +29,8 @@ limitations under the License.
   errors = require('resin-errors');
 
   request = require('resin-request');
+
+  settings = require('resin-settings-client');
 
   registerDevice = require('resin-register-device');
 
@@ -436,6 +438,7 @@ limitations under the License.
       return request.send({
         method: 'POST',
         url: '/blink',
+        baseUrl: settings.get('apiUrl'),
         body: {
           uuid: uuid
         }
@@ -598,7 +601,8 @@ limitations under the License.
     return exports.get(uuid).then(function(device) {
       return request.send({
         method: 'POST',
-        url: "/device/" + device.id + "/restart"
+        url: "/device/" + device.id + "/restart",
+        baseUrl: settings.get('apiUrl')
       });
     }).get('body').nodeify(callback);
   };
@@ -628,6 +632,7 @@ limitations under the License.
       return request.send({
         method: 'POST',
         url: '/supervisor/v1/reboot',
+        baseUrl: settings.get('apiUrl'),
         body: {
           deviceId: device.id
         }

--- a/build/models/os.js
+++ b/build/models/os.js
@@ -16,21 +16,13 @@ limitations under the License.
  */
 
 (function() {
-  var errors, getImageMakerUrl, request, settings, url;
-
-  url = require('url');
+  var errors, request, settings;
 
   request = require('resin-request');
 
   errors = require('resin-errors');
 
   settings = require('resin-settings-client');
-
-  getImageMakerUrl = function(deviceType) {
-    var imageMakerUrl;
-    imageMakerUrl = settings.get('imageMakerUrl');
-    return url.resolve(imageMakerUrl, "/api/v1/image/" + deviceType + "/");
-  };
 
 
   /**
@@ -58,7 +50,8 @@ limitations under the License.
   exports.getLastModified = function(deviceType, callback) {
     return request.send({
       method: 'HEAD',
-      url: getImageMakerUrl(deviceType)
+      url: "/api/v1/image/" + deviceType + "/",
+      baseUrl: settings.get('imageMakerUrl')
     })["catch"]({
       name: 'ResinRequestError',
       statusCode: 404
@@ -95,7 +88,8 @@ limitations under the License.
   exports.download = function(deviceType, callback) {
     return request.stream({
       method: 'GET',
-      url: getImageMakerUrl(deviceType)
+      url: "/api/v1/image/" + deviceType + "/",
+      baseUrl: settings.get('imageMakerUrl')
     }).nodeify(callback);
   };
 

--- a/lib/2fa.coffee
+++ b/lib/2fa.coffee
@@ -16,6 +16,7 @@ limitations under the License.
 
 token = require('resin-token')
 request = require('resin-request')
+settings = require('resin-settings-client')
 
 ###*
 # @summary Check if two factor authentication is enabled
@@ -101,6 +102,7 @@ exports.challenge = (code, callback) ->
 	request.send
 		method: 'POST'
 		url: '/auth/totp/verify'
+		baseUrl: settings.get('apiUrl')
 		body: { code }
 	.get('body')
 	.then(token.set)

--- a/lib/auth.coffee
+++ b/lib/auth.coffee
@@ -17,6 +17,7 @@ limitations under the License.
 errors = require('resin-errors')
 request = require('resin-request')
 token = require('resin-token')
+settings = require('resin-settings-client')
 
 ###*
 # @namespace resin.auth.twoFactor
@@ -93,6 +94,7 @@ exports.whoami = (callback) ->
 exports.authenticate = (credentials, callback) ->
 	request.send
 		method: 'POST'
+		baseUrl: settings.get('apiUrl')
 		url: '/login_'
 		body:
 			username: credentials.email
@@ -186,6 +188,7 @@ exports.isLoggedIn = (callback) ->
 	request.send
 		method: 'GET'
 		url: '/whoami'
+		baseUrl: settings.get('apiUrl')
 	.return(true)
 	.catch ->
 		return false
@@ -333,6 +336,7 @@ exports.register = (credentials = {}, callback) ->
 	request.send
 		method: 'POST'
 		url: '/user/register'
+		baseUrl: settings.get('apiUrl')
 		body: credentials
 	.get('body')
 	.nodeify(callback)

--- a/lib/models/application.coffee
+++ b/lib/models/application.coffee
@@ -17,6 +17,7 @@ limitations under the License.
 _ = require('lodash')
 errors = require('resin-errors')
 request = require('resin-request')
+settings = require('resin-settings-client')
 token = require('resin-token')
 pine = require('resin-pine')
 deviceModel = require('./device')
@@ -270,6 +271,7 @@ exports.restart = (name, callback) ->
 		return request.send
 			method: 'POST'
 			url: "/application/#{application.id}/restart"
+			baseUrl: settings.get('apiUrl')
 	.return(undefined)
 	.nodeify(callback)
 
@@ -300,5 +302,6 @@ exports.getApiKey = (name, callback) ->
 		return request.send
 			method: 'POST'
 			url: "/application/#{application.id}/generate-api-key"
+			baseUrl: settings.get('apiUrl')
 	.get('body')
 	.nodeify(callback)

--- a/lib/models/config.coffee
+++ b/lib/models/config.coffee
@@ -16,6 +16,7 @@ limitations under the License.
 
 _ = require('lodash')
 request = require('resin-request')
+settings = require('resin-settings-client')
 deviceModel = require('./device')
 
 ###*
@@ -43,6 +44,7 @@ exports.getAll = (callback) ->
 	request.send
 		method: 'GET'
 		url: '/config'
+		baseUrl: settings.get('apiUrl')
 	.get('body')
 	.then (body) ->
 

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -20,6 +20,7 @@ _ = require('lodash')
 pine = require('resin-pine')
 errors = require('resin-errors')
 request = require('resin-request')
+settings = require('resin-settings-client')
 registerDevice = require('resin-register-device')
 deviceStatus = require('resin-device-status')
 configModel = require('./config')
@@ -391,6 +392,7 @@ exports.identify = (uuid, callback) ->
 		return request.send
 			method: 'POST'
 			url: '/blink'
+			baseUrl: settings.get('apiUrl')
 			body:
 				uuid: uuid
 	.return(undefined)
@@ -534,6 +536,7 @@ exports.restart = (uuid, callback) ->
 		return request.send
 			method: 'POST'
 			url: "/device/#{device.id}/restart"
+			baseUrl: settings.get('apiUrl')
 	.get('body')
 	.nodeify(callback)
 
@@ -560,6 +563,7 @@ exports.reboot = (uuid, callback) ->
 		return request.send
 			method: 'POST'
 			url: '/supervisor/v1/reboot'
+			baseUrl: settings.get('apiUrl')
 			body:
 				deviceId: device.id
 	.get('body')

--- a/lib/models/os.coffee
+++ b/lib/models/os.coffee
@@ -14,14 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ###
 
-url = require('url')
 request = require('resin-request')
 errors = require('resin-errors')
 settings = require('resin-settings-client')
-
-getImageMakerUrl = (deviceType) ->
-	imageMakerUrl = settings.get('imageMakerUrl')
-	return url.resolve(imageMakerUrl, "/api/v1/image/#{deviceType}/")
 
 ###*
 # @summary Get OS image last modified date
@@ -47,7 +42,8 @@ getImageMakerUrl = (deviceType) ->
 exports.getLastModified = (deviceType, callback) ->
 	request.send
 		method: 'HEAD'
-		url: getImageMakerUrl(deviceType)
+		url: "/api/v1/image/#{deviceType}/"
+		baseUrl: settings.get('imageMakerUrl')
 	.catch
 		name: 'ResinRequestError'
 		statusCode: 404
@@ -81,5 +77,6 @@ exports.getLastModified = (deviceType, callback) ->
 exports.download = (deviceType, callback) ->
 	request.stream
 		method: 'GET'
-		url: getImageMakerUrl(deviceType)
+		url: "/api/v1/image/#{deviceType}/"
+		baseUrl: settings.get('imageMakerUrl')
 	.nodeify(callback)


### PR DESCRIPTION
This allows `resin-request` to be decoupled from
`resin-settings-client`, as a first step of decoupling the SDK from the
environment settings.