### PR TITLE
Change supervisor semver check to >= 1.8.0-alpha.0 for /apps endpoint

### DIFF
--- a/build/models/device.js
+++ b/build/models/device.js
@@ -44,7 +44,7 @@ limitations under the License.
 
   auth = require('../auth');
 
-  MIN_SUPERVISOR_APPS_API = '1.8.0';
+  MIN_SUPERVISOR_APPS_API = '1.8.0-alpha.0';
 
 
   /**

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -28,7 +28,11 @@ configModel = require('./config')
 applicationModel = require('./application')
 auth = require('../auth')
 
-MIN_SUPERVISOR_APPS_API = '1.8.0'
+# The min version where /apps API endpoints are implemented is 1.8.0 but we'll
+# be accepting >= 1.8.0-alpha.0 instead. This is a workaround for a published 1.8.0-p1
+# prerelase supervisor version, which precedes 1.8.0 but comes after 1.8.0-alpha.0
+# according to semver.
+MIN_SUPERVISOR_APPS_API = '1.8.0-alpha.0'
 
 ###*
 # @summary Ensure supervisor version compatibility using semver


### PR DESCRIPTION
One alternative is to check if version is greater than all the versions possible in the `1.7` range with `semver.gtr(detected_version, 1.7)`, changing the semantics of `ensureSupervisorCompatibility()` accordingly and having a `SUPERVISOR_APPS_API_MAX_INCOMPATIBLE_RANGE` constant (or similar) to hold `1.7`. 

A benefit of the `gtr()` alternative is that users will get a friendlier message ("*version should be > 1.7*" instead of this PR's "*version should be >= 1.8.0-alpha.0*"), the drawback is that it complicates the semantics of `ensureSupervisorCompatibility()`- @shaunmulligan @jviotti @Page- ideas?