### PR TITLE
Expand shorter uuids in resin.models.device.move()

### DIFF
--- a/build/models/device.js
+++ b/build/models/device.js
@@ -646,7 +646,7 @@ limitations under the License.
         },
         options: {
           filter: {
-            uuid: uuid
+            uuid: results.device.uuid
           }
         }
       });

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -582,7 +582,7 @@ exports.move = (uuid, application, callback) ->
 				application: results.application.id
 			options:
 				filter:
-					uuid: uuid
+					uuid: results.device.uuid
 
 	.nodeify(callback)
 

--- a/tests/integration.coffee
+++ b/tests/integration.coffee
@@ -1097,6 +1097,13 @@ describe 'SDK Integration Tests', ->
 						m.chai.expect(applicationName).to.equal(@application2.app_name)
 					.nodeify(done)
 
+				it 'should be able to move a device using shorter uuids', (done) ->
+					resin.models.device.move(@device.uuid.slice(0, 7), @application2.app_name).then =>
+						resin.models.device.getApplicationName(@device.uuid)
+					.then (applicationName) =>
+						m.chai.expect(applicationName).to.equal(@application2.app_name)
+					.nodeify(done)
+
 		describe 'given two incompatible applications and a single device', ->
 
 			beforeEach (done) ->


### PR DESCRIPTION
If a user passed a shorted uuid to `resin.models.device.move()`, the
operation would fail without an error message (the device would still be
on the older app) since the uuid was not being expanded into a full
uuid before being used in the `pine`, which only understands full uuids.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>