### PR TITLE
Make sure shorter uuids are expanded before passing to pine

### DIFF
--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -435,12 +435,12 @@ exports.getLocalIPAddresses = (uuid, callback) ->
 # });
 ###
 exports.remove = (uuid, callback) ->
-	exports.get(uuid).then ->
+	exports.get(uuid).then (device) ->
 		return pine.delete
 			resource: 'device'
 			options:
 				filter:
-					uuid: uuid
+					uuid: device.uuid
 	.nodeify(callback)
 
 ###*
@@ -462,17 +462,13 @@ exports.remove = (uuid, callback) ->
 # });
 ###
 exports.identify = (uuid, callback) ->
-	exports.has(uuid).then (hasDevice) ->
-
-		if not hasDevice
-			throw new errors.ResinDeviceNotFound(uuid)
-
+	exports.get(uuid).then (device) ->
 		return request.send
 			method: 'POST'
 			url: '/blink'
 			baseUrl: settings.get('apiUrl')
 			body:
-				uuid: uuid
+				uuid: device.uuid
 	.return(undefined)
 	.nodeify(callback)
 
@@ -497,18 +493,14 @@ exports.identify = (uuid, callback) ->
 # });
 ###
 exports.rename = (uuid, newName, callback) ->
-	exports.has(uuid).then (hasDevice) ->
-
-		if not hasDevice
-			throw new errors.ResinDeviceNotFound(uuid)
-
+	exports.get(uuid).then (device) ->
 		return pine.patch
 			resource: 'device'
 			body:
 				name: newName
 			options:
 				filter:
-					uuid: uuid
+					uuid: device.uuid
 	.nodeify(callback)
 
 ###*
@@ -532,18 +524,14 @@ exports.rename = (uuid, newName, callback) ->
 # });
 ###
 exports.note = (uuid, note, callback) ->
-	exports.has(uuid).then (hasDevice) ->
-
-		if not hasDevice
-			throw new errors.ResinDeviceNotFound(uuid)
-
+	exports.get(uuid).then (device) ->
 		return pine.patch
 			resource: 'device'
 			body:
 				note: note
 			options:
 				filter:
-					uuid: uuid
+					uuid: device.uuid
 
 	.nodeify(callback)
 
@@ -1157,18 +1145,14 @@ exports.getDeviceUrl = (uuid, callback) ->
 # });
 ###
 exports.enableDeviceUrl = (uuid, callback) ->
-	exports.has(uuid).then (hasDevice) ->
-
-		if not hasDevice
-			throw new errors.ResinDeviceNotFound(uuid)
-
+	exports.get(uuid).then (device) ->
 		return pine.patch
 			resource: 'device'
 			body:
 				is_web_accessible: true
 			options:
 				filter:
-					uuid: uuid
+					uuid: device.uuid
 	.nodeify(callback)
 
 ###*
@@ -1190,18 +1174,14 @@ exports.enableDeviceUrl = (uuid, callback) ->
 # });
 ###
 exports.disableDeviceUrl = (uuid, callback) ->
-	exports.has(uuid).then (hasDevice) ->
-
-		if not hasDevice
-			throw new errors.ResinDeviceNotFound(uuid)
-
+	exports.get(uuid).then (device) ->
 		return pine.patch
 			resource: 'device'
 			body:
 				is_web_accessible: false
 			options:
 				filter:
-					uuid: uuid
+					uuid: device.uuid
 	.nodeify(callback)
 
 ###*

--- a/tests/integration.coffee
+++ b/tests/integration.coffee
@@ -849,6 +849,13 @@ describe 'SDK Integration Tests', ->
 								m.chai.expect(devices).to.deep.equal([])
 					  .nodeify(done)
 
+					it 'should be able to remove the device using a shorter uuid', (done) ->
+						resin.models.device.remove(@device.uuid.slice(0, 7))
+							.then(resin.models.device.getAll)
+							.then (devices) ->
+								m.chai.expect(devices).to.deep.equal([])
+					  .nodeify(done)
+
 					it 'should be rejected if the device does not exist', ->
 						promise = resin.models.device.remove('asdfghjkl')
 						m.chai.expect(promise).to.be.rejectedWith('Device not found: asdfghjkl')
@@ -857,6 +864,13 @@ describe 'SDK Integration Tests', ->
 
 					it 'should be able to rename the device', (done) ->
 						resin.models.device.rename(@device.uuid, 'FooBarDevice').then =>
+							resin.models.device.getName(@device.uuid)
+						.then (name) ->
+							m.chai.expect(name).to.equal('FooBarDevice')
+						.nodeify(done)
+
+					it 'should be able to rename the device using a shorter uuid', (done) ->
+						resin.models.device.rename(@device.uuid.slice(0, 7), 'FooBarDevice').then =>
 							resin.models.device.getName(@device.uuid)
 						.then (name) ->
 							m.chai.expect(name).to.equal('FooBarDevice')
@@ -909,6 +923,12 @@ describe 'SDK Integration Tests', ->
 								m.chai.expect(promise).to.eventually.be.true
 							.nodeify(done)
 
+						it 'should be able to enable web access using a shorter uuid', (done) ->
+							resin.models.device.enableDeviceUrl(@device.uuid.slice(0, 7)).then =>
+								promise = resin.models.device.hasDeviceUrl(@device.uuid)
+								m.chai.expect(promise).to.eventually.be.true
+							.nodeify(done)
+
 						it 'should be rejected if the device does not exist', ->
 							promise = resin.models.device.enableDeviceUrl('asdfghjkl')
 							m.chai.expect(promise).to.be.rejectedWith('Device not found: asdfghjkl')
@@ -943,6 +963,12 @@ describe 'SDK Integration Tests', ->
 
 						it 'should be able to disable web access', (done) ->
 							resin.models.device.disableDeviceUrl(@device.uuid).then =>
+								promise = resin.models.device.hasDeviceUrl(@device.uuid)
+								m.chai.expect(promise).to.eventually.be.false
+							.nodeify(done)
+
+						it 'should be able to disable web access using a shorter uuid', (done) ->
+							resin.models.device.disableDeviceUrl(@device.uuid.slice(0, 7)).then =>
 								promise = resin.models.device.hasDeviceUrl(@device.uuid)
 								m.chai.expect(promise).to.eventually.be.false
 							.nodeify(done)


### PR DESCRIPTION
If the user passes a shorter uuid, and then we use this shorter uuid as
a pine filter, it will match nothing, causing no errors but no real
action, which can be very hard to debug.

As a fix, we call `resin.models.device.get()` with the shorter uuid, and
access the resulting `.uuid` field, which is ensured to be the full one,
before passing it to pine.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>