### PR TITLE
Make the tests stable

### DIFF
--- a/karma.conf.coffee
+++ b/karma.conf.coffee
@@ -12,7 +12,7 @@ module.exports = (config) ->
 		captureConsole: true
 
 	karmaConfig.plugins.push(require('karma-env-preprocessor'))
-	karmaConfig.preprocessors['**/*.spec.coffee'] = [ 'env' ]
+	karmaConfig.preprocessors['**/*.spec.coffee'] = [ 'browserify', 'env' ]
 	karmaConfig.envPreprocessor = [
 		'RESINTEST_EMAIL'
 		'RESINTEST_PASSWORD'

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "resin-errors": "^2.4.0",
     "resin-pine": "^4.0.0",
     "resin-register-device": "^2.1.1",
-    "resin-request": "^6.1.0",
+    "resin-request": "^6.2.0",
     "resin-token": "^3.0.0",
     "semver": "^5.1.0"
   }

--- a/tests/integration.spec.coffee
+++ b/tests/integration.spec.coffee
@@ -41,6 +41,8 @@ _.assign opts,
 	apiKey: null
 	isBrowser: IS_BROWSER,
 	isTest: true
+	debug: true
+	retries: 3
 
 pine = getPine(opts)
 resinRequest = getResinRequest(opts)

--- a/tests/integration.spec.coffee
+++ b/tests/integration.spec.coffee
@@ -41,7 +41,6 @@ _.assign opts,
 	apiKey: null
 	isBrowser: IS_BROWSER,
 	isTest: true
-	debug: true
 	retries: 3
 
 pine = getPine(opts)

--- a/tests/util.coffee
+++ b/tests/util.coffee
@@ -1,2 +1,2 @@
 exports.loadEnv = ->
-	require('dotenv').config()
+	require('dotenv').config(silent: true)


### PR DESCRIPTION
This fixes #237, building on top of #236.

This change is very simple, just fixes a Karma config bug (arguably a Karma bug, see karma-runner/karma#2505), brings in the new resin-request and puts resin-io-modules/resin-request#78 and resin-io-modules/resin-request#79 to use.

End result is that we now output some debug info during the tests about the requests being made, and retry failing requests. The debug output is just so we can debug this better if it does start to go wrong later - it's a bit noisy for now, but we can remove it soon once we're sure this change makes the tests stable.