### PR TITLE
Update to support the new device registration flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+### Changed
+
+- **Breaking!** Changed `register()` to work with the new device registration flow. `register()` now return device registration information (`{ id: "...", uuid: "...", api_key: "..." }`), but not the full device object.
+- **Breaking!** Changed `generateUUID()` to `generateUniqueKey()` to reflect that it should now be used for both generating a uuid and an api key.
+
 ## [5.4.0] - 2016-10-27
 
 ### Added

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -50,7 +50,7 @@ If you feel something is missing, not clear or could be improved, please don't h
             * [.getSupportedDeviceTypes()](#resin.models.device.getSupportedDeviceTypes) ⇒ <code>Promise</code>
             * [.getManifestBySlug(slug)](#resin.models.device.getManifestBySlug) ⇒ <code>Promise</code>
             * [.getManifestByApplication(applicationName)](#resin.models.device.getManifestByApplication) ⇒ <code>Promise</code>
-            * [.generateUUID()](#resin.models.device.generateUUID) ⇒ <code>Promise</code>
+            * [.generateUniqueKey()](#resin.models.device.generateUniqueKey) ⇒ <code>String</code>
             * [.register(applicationName, uuid)](#resin.models.device.register) ⇒ <code>Promise</code>
             * [.hasDeviceUrl(uuid)](#resin.models.device.hasDeviceUrl) ⇒ <code>Promise</code>
             * [.getDeviceUrl(uuid)](#resin.models.device.getDeviceUrl) ⇒ <code>Promise</code>
@@ -152,7 +152,7 @@ If you feel something is missing, not clear or could be improved, please don't h
         * [.getSupportedDeviceTypes()](#resin.models.device.getSupportedDeviceTypes) ⇒ <code>Promise</code>
         * [.getManifestBySlug(slug)](#resin.models.device.getManifestBySlug) ⇒ <code>Promise</code>
         * [.getManifestByApplication(applicationName)](#resin.models.device.getManifestByApplication) ⇒ <code>Promise</code>
-        * [.generateUUID()](#resin.models.device.generateUUID) ⇒ <code>Promise</code>
+        * [.generateUniqueKey()](#resin.models.device.generateUniqueKey) ⇒ <code>String</code>
         * [.register(applicationName, uuid)](#resin.models.device.register) ⇒ <code>Promise</code>
         * [.hasDeviceUrl(uuid)](#resin.models.device.hasDeviceUrl) ⇒ <code>Promise</code>
         * [.getDeviceUrl(uuid)](#resin.models.device.getDeviceUrl) ⇒ <code>Promise</code>
@@ -446,7 +446,7 @@ resin.models.application.getApiKey('MyApp', function(error, apiKey) {
     * [.getSupportedDeviceTypes()](#resin.models.device.getSupportedDeviceTypes) ⇒ <code>Promise</code>
     * [.getManifestBySlug(slug)](#resin.models.device.getManifestBySlug) ⇒ <code>Promise</code>
     * [.getManifestByApplication(applicationName)](#resin.models.device.getManifestByApplication) ⇒ <code>Promise</code>
-    * [.generateUUID()](#resin.models.device.generateUUID) ⇒ <code>Promise</code>
+    * [.generateUniqueKey()](#resin.models.device.generateUniqueKey) ⇒ <code>String</code>
     * [.register(applicationName, uuid)](#resin.models.device.register) ⇒ <code>Promise</code>
     * [.hasDeviceUrl(uuid)](#resin.models.device.hasDeviceUrl) ⇒ <code>Promise</code>
     * [.getDeviceUrl(uuid)](#resin.models.device.getDeviceUrl) ⇒ <code>Promise</code>
@@ -1132,33 +1132,26 @@ resin.models.device.getManifestByApplication('MyApp', function(error, manifest) 
 	console.log(manifest);
 });
 ```
-<a name="resin.models.device.generateUUID"></a>
+<a name="resin.models.device.generateUniqueKey"></a>
 
-##### device.generateUUID() ⇒ <code>Promise</code>
+##### device.generateUniqueKey() ⇒ <code>String</code>
 **Kind**: static method of <code>[device](#resin.models.device)</code>  
-**Summary**: Generate a random device UUID  
+**Summary**: Generate a random key, useful for both uuid and api key.  
+**Returns**: <code>String</code> - - a generated key  
 **Access:** public  
-**Fulfil**: <code>String</code> - a generated UUID  
 **Example**  
 ```js
-resin.models.device.generateUUID().then(function(uuid) {
-	console.log(uuid);
-});
-```
-**Example**  
-```js
-resin.models.device.generateUUID(function(error, uuid) {
-	if (error) throw error;
-	console.log(uuid);
-});
+randomKey = resin.models.device.generateUniqueKey();
+// randomKey is a randomly generated key that can be used as either a uuid or an api key
+console.log(randomKey);
 ```
 <a name="resin.models.device.register"></a>
 
 ##### device.register(applicationName, uuid) ⇒ <code>Promise</code>
 **Kind**: static method of <code>[device](#resin.models.device)</code>  
-**Summary**: Register a new device with a Resin.io application. **Should not be used in the browser.**  
+**Summary**: Register a new device with a Resin.io application.  
 **Access:** public  
-**Fulfil**: <code>Object</code> - device  
+**Fulfil**: <code>Object</code> - device registration info  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1167,22 +1160,17 @@ resin.models.device.generateUUID(function(error, uuid) {
 
 **Example**  
 ```js
-resin.models.device.generateUUID().then(function(uuid) {
-	resin.models.device.register('MyApp', uuid).then(function(device) {
-		console.log(device);
-	});
+var uuid = resin.models.device.generateUniqueKey();
+resin.models.device.register('MyApp', uuid).then(function(registrationInfo) {
+	console.log(registrationInfo);
 });
 ```
 **Example**  
 ```js
-resin.models.device.generateUUID(function(error, uuid) {
+var uuid = resin.models.device.generateUniqueKey();
+resin.models.device.register('MyApp', uuid, function(error, registrationInfo) {
 	if (error) throw error;
-
-	resin.models.device.register('MyApp', uuid, function(error, device) {
-		if (error) throw error;
-
-		console.log(device);
-	});
+	console.log(registrationInfo);
 });
 ```
 <a name="resin.models.device.hasDeviceUrl"></a>

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "resin-device-status": "^1.0.1",
     "resin-errors": "^2.4.0",
     "resin-pine": "^4.0.0",
-    "resin-register-device": "^2.1.1",
+    "resin-register-device": "^3.0.0",
     "resin-request": "^6.2.0",
     "resin-token": "^3.0.0",
     "semver": "^5.1.0"

--- a/tests/integration.spec.coffee
+++ b/tests/integration.spec.coffee
@@ -1145,8 +1145,6 @@ describe 'SDK Integration Tests', ->
 		describe 'OS Model', ->
 
 			describe 'resin.models.os.getLastModified()', ->
-				# TODO: can be reenabled after the CORS PR is deployed to prod
-				return if IS_BROWSER
 
 				describe 'given a valid device slug', ->
 


### PR DESCRIPTION
This PR fixes #232 by pulling in resin-register-device@3 (see resin-io/resin-register-device#22 and resin-io/resin-register-device#25 for background).

This PR brings the resin-sdk API in line with resin-register-device, and that adds the various changes to the tests required to make this work. Device registration now works in Node and browsers. Also clarifies some tests and reenables some tests that were [temporarily disabled 2 months ago](https://github.com/resin-io/resin-sdk/blob/af90835dee327bb450239bc768aeea56b09cdc6d/tests/integration.spec.coffee#L1210), and now pass.

I've favoured internal consistency for this change over backward compatibility here, which is debatable. Breaking changes are:

* generateUUID is now generateUniqueKey, and is no longer async
* register no longer returns the device, now just `{ id, uuid, api_key }`).

These are more or less the same APIs as resin-register-device. We could transform these here to make this backward compatible (wrapping generateUniqueKey to make it async; doing an extra request after every register call to get the device and then attaching api_key to that result) but both of those changes are a little messy internally and have downsides. _If_ we're happy breaking compatibility, I think this PR is the better end result.

Other minor point is that I've called the new `{ id, uuid, api_key }` return type "device registration info", but I haven't described the format anywhere, so it's not easy for users to know exactly what'll be in that. Can't see any examples of how we document return object types in JSDoc, let me know if there's a clear way I should add more detail.

This PR is on top of #239, because otherwise the tests won't pass, and I've used that as a base for this PR so you can see the changes here independently. I'll can shift it to `sdk-browser` once the tests PR has been merged.