### PR TITLE
Safely stop tests and build running on npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "test-node": "gulp test",
     "test-browser": "karma start",
     "build": "gulp build",
-    "prepublish": "(not-in-publish && echo 'Skipping prepublish') || npm run require-NPM4-to-publish",
-    "require-NPM4-to-publish": "semver -r '>=4.0.0' $(npm --version) || (echo 'NPM 4+ required to publish, run: sudo npm install -g npm' && exit 1)",
+    "prepublish": "(not-in-publish && echo 'Skipping prepublish') || npm run require-npm4-to-publish",
+    "require-npm4-to-publish": "semver -r '>=4.0.0' $(npm --version) || (echo 'NPM 4+ required to publish, run: sudo npm install -g npm' && exit 1)",
     "prepublishOnly": "npm test && npm run build",
     "docs": "jsdoc2md build/{,**/}*.js > DOCUMENTATION.md"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "test-node": "gulp test",
     "test-browser": "karma start",
     "build": "gulp build",
-    "prepublish": "npm test && npm run build",
+    "prepublish": "(not-in-publish && echo 'Skipping prepublish') || npm run require-NPM4-to-publish",
+    "require-NPM4-to-publish": "semver -r '>=4.0.0' $(npm --version) || (echo 'NPM 4+ required to publish, run: sudo npm install -g npm' && exit 1)",
+    "prepublishOnly": "npm test && npm run build",
     "docs": "jsdoc2md build/{,**/}*.js > DOCUMENTATION.md"
   },
   "author": "Juan Cruz Viotti <juan@resin.io>",
@@ -37,6 +39,7 @@
     "gulp-coffeelint": "^0.6.0",
     "gulp-mocha": "^3.0.0",
     "gulp-util": "^3.0.4",
+    "in-publish": "^2.0.0",
     "isomorphic-fetch": "^2.2.1",
     "jsdoc-to-markdown": "^2.0.1",
     "karma": "^1.3.0",
@@ -48,6 +51,7 @@
     "resin-settings-client": "^3.5.2",
     "rindle": "^1.2.0",
     "run-sequence": "^1.1.0",
+    "semver": "^5.3.0",
     "superagent": "^3.0.0",
     "tmp": "^0.0.31"
   },


### PR DESCRIPTION
This halves the number of tests we run, working towards #241.

This script makes NPM `prepublish` never run the tests or CS build. Instead, those are run in NPM@4's new `prepublishOnly` step, which _only_ happens on an actual publish, not on simple `npm install`'s.

To make this safe, we have to catch any users that aren't using NPM@4, but are trying to publish - `require-NPM4-to-publish` does that, and gets triggered by any actual publishes when they trigger `prepublish`.

Tested locally with NPM 4.0.3 and NPM 3.10.10.