### PR TITLE
Stop appveyor building branches that already in PRs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 # appveyor file
 # http://www.appveyor.com/docs/appveyor-yml
 
+skip_branch_with_pr: true
+
 init:
   - git config --global core.autocrlf input
 


### PR DESCRIPTION
This is the last step to fix #241.

Currently, we build for every PR update (building the PR+master commit) and for every branch push. The branch alone isn't really interesting though, and once a PR is open it'll get built by PR triggers anyway. With this (tiny) change, only that PR build happens, rather than effectively duplicating every build job.

Docs for this option are minimal at best, but https://github.com/appveyor/ci/issues/882 has some background. 