### PR TITLE
Automatically publish tagged master commits to npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,22 @@
 language: node_js
 node_js:
-  - "6"
-  - "4"
+- '6'
+- '4'
 before_install:
-  - npm -g install npm
+- npm -g install npm
 notifications:
   email: false
   webhooks:
     urls:
-      - https://webhooks.gitter.im/e/8b150eaf525c280ec2ac
+    - https://webhooks.gitter.im/e/8b150eaf525c280ec2ac
     on_success: change
     on_failure: always
     on_start: never
+deploy:
+  provider: npm
+  email: 'accounts@resin.io'
+  api_key:
+    secure: SKemSDObFtG2GnVxhmxR4KMr/5S8LwlVdbgom3ouQ/kXAfMY0n6KaV6nwM+4EhW9zg6A8r2XQ6Q7fWs+ESwNvk1dS6MAHwdC5KOUpVqeRxsAuyZnIRdwa0J9wMbzt2I0E9D0sTvi4FZSO9a/6fJDWUrbTFP7Dv/S3ngyQz014ZY=
+  on:
+    tags: true
+    repo: resin-io/resin-sdk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+### Changed
+
+- Tagged commits are now automatically published to npm
+
 ## [6.0.1] - 2017-04-12
 
 ### Changed


### PR DESCRIPTION
This is the first step to adding versionbot to the SDK. With this, any time we tag a change, travis will publish it to npm. That should mean once we add versionbot, versionbot merges will automatically publish the new version to npm. Neat! This uses the resin.io credentials, but with the standard travis encryption setup to keep them hidden.

This does mean we don't have to sit and wait for the publish tests to run for us locally, but I suspect it also means we'll have to deal with instability on deploy occasionally from #252. That needs solving independently anyway (although I still don't have a useful answer).

Some reformatting here because I set this up with the travis cli tool, and it doesn't like our yaml formatting, I'm inclined to stick with its decisions there.

This might be of interest to @hedss, since this is our solution to https://github.com/resin-io-modules/resin-procbots/issues/30.