### PR TITLE
Drop unnecessary direct pinejs-client-dep dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
   "dependencies": {
     "bluebird": "^3.3.1",
     "lodash": "^4.4.0",
-    "pinejs-client": "^3.1.0",
     "promise-memoize": "^1.2.0",
     "resin-device-logs": "^3.1.0",
     "resin-device-status": "^1.0.1",


### PR DESCRIPTION
Connects to https://github.com/resin-io/resin-ui/issues/643