### PR TITLE
Travis now runs builds against commits on master, in addition to PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,6 @@ deploy:
   on:
     tags: true
     repo: resin-io/resin-sdk
+branches:
+  only:
+    - "master"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+### Changed
+
+- Travis now runs builds against commits on master, in addition to PRs, to solve #309
+
 ## [6.1.0] - 2017-04-26
 
 ### Added


### PR DESCRIPTION
Connects to #309.

I've also now re-enabled branch builds in travis itself. I think with these two together this should now work - need to wait until the next SDK release to test it.