### PR TITLE
Build & deploy all version-tagged branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ deploy:
     repo: resin-io/resin-sdk
 branches:
   only:
-    - "master"
+    - /^v?\d+\.\d+\.\d+.*/


### PR DESCRIPTION
A footnote on https://docs.travis-ci.com/user/customizing-the-build#Safelisting-or-blocklisting-branches points out that the `branches` setting also applies to tags, so if we want to deploy tags but no build every branch build, then we need to explicitly whitelist the tags we'd like Travis to build.

This updates the config so that any tag which starts with a format like `v1.2.3` (optional v) is automatically deployed.