### PR TITLE
Break everything we can pre-v3

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -20,7 +20,7 @@ If you feel something is missing, not clear or could be improved, please don't h
         * [.application](#resin.models.application) : <code>object</code>
             * [.getAll([options])](#resin.models.application.getAll) ⇒ <code>Promise</code>
             * [.get(nameOrId, [options])](#resin.models.application.get) ⇒ <code>Promise</code>
-            * [.getAppWithOwner(appName, owner, [options])](#resin.models.application.getAppWithOwner) ⇒ <code>Promise</code>
+            * [.getAppByOwner(appName, owner, [options])](#resin.models.application.getAppByOwner) ⇒ <code>Promise</code>
             * [.has(nameOrId)](#resin.models.application.has) ⇒ <code>Promise</code>
             * [.hasAny()](#resin.models.application.hasAny) ⇒ <code>Promise</code>
             * ~~[.getById(id)](#resin.models.application.getById) ⇒ <code>Promise</code>~~
@@ -268,7 +268,7 @@ resin.models.device.get(123).catch(function (error) {
     * [.application](#resin.models.application) : <code>object</code>
         * [.getAll([options])](#resin.models.application.getAll) ⇒ <code>Promise</code>
         * [.get(nameOrId, [options])](#resin.models.application.get) ⇒ <code>Promise</code>
-        * [.getAppWithOwner(appName, owner, [options])](#resin.models.application.getAppWithOwner) ⇒ <code>Promise</code>
+        * [.getAppByOwner(appName, owner, [options])](#resin.models.application.getAppByOwner) ⇒ <code>Promise</code>
         * [.has(nameOrId)](#resin.models.application.has) ⇒ <code>Promise</code>
         * [.hasAny()](#resin.models.application.hasAny) ⇒ <code>Promise</code>
         * ~~[.getById(id)](#resin.models.application.getById) ⇒ <code>Promise</code>~~
@@ -377,7 +377,7 @@ resin.models.device.get(123).catch(function (error) {
 * [.application](#resin.models.application) : <code>object</code>
     * [.getAll([options])](#resin.models.application.getAll) ⇒ <code>Promise</code>
     * [.get(nameOrId, [options])](#resin.models.application.get) ⇒ <code>Promise</code>
-    * [.getAppWithOwner(appName, owner, [options])](#resin.models.application.getAppWithOwner) ⇒ <code>Promise</code>
+    * [.getAppByOwner(appName, owner, [options])](#resin.models.application.getAppByOwner) ⇒ <code>Promise</code>
     * [.has(nameOrId)](#resin.models.application.has) ⇒ <code>Promise</code>
     * [.hasAny()](#resin.models.application.hasAny) ⇒ <code>Promise</code>
     * ~~[.getById(id)](#resin.models.application.getById) ⇒ <code>Promise</code>~~
@@ -451,9 +451,9 @@ resin.models.application.get('MyApp', function(error, application) {
 	console.log(application);
 });
 ```
-<a name="resin.models.application.getAppWithOwner"></a>
+<a name="resin.models.application.getAppByOwner"></a>
 
-##### application.getAppWithOwner(appName, owner, [options]) ⇒ <code>Promise</code>
+##### application.getAppByOwner(appName, owner, [options]) ⇒ <code>Promise</code>
 **Kind**: static method of <code>[application](#resin.models.application)</code>  
 **Summary**: Get a single application using the appname and owner's username  
 **Access**: public  
@@ -467,7 +467,7 @@ resin.models.application.get('MyApp', function(error, application) {
 
 **Example**  
 ```js
-resin.models.application.getAppWithOwner('MyApp', 'MyUser').then(function(application) {
+resin.models.application.getAppByOwner('MyApp', 'MyUser').then(function(application) {
 	console.log(application);
 });
 ```

--- a/lib/models/application.coffee
+++ b/lib/models/application.coffee
@@ -83,7 +83,6 @@ getApplicationModel = (deps, opts) ->
 				options:
 					mergePineOptions
 						orderby: 'app_name asc'
-						expand: 'device'
 						filter:
 							user: userId
 					, options
@@ -187,15 +186,14 @@ getApplicationModel = (deps, opts) ->
 						$eq: [
 							$tolower: $: 'app_name'
 							appName
-						]
-					expand:
+						],
 						user:
-							$filter:
-								$eq: [
+							$any:
+								$alias: 'u',
+								$expr: $eq: [
 									$tolower: $: 'username'
 									owner
 								]
-							$select: 'id'
 				, options
 		.tap (applications) ->
 			if isEmpty(applications)

--- a/lib/models/application.coffee
+++ b/lib/models/application.coffee
@@ -156,7 +156,7 @@ getApplicationModel = (deps, opts) ->
 
 	###*
 	# @summary Get a single application using the appname and owner's username
-	# @name getAppWithOwner
+	# @name getAppByOwner
 	# @public
 	# @function
 	# @memberof resin.models.application
@@ -168,11 +168,11 @@ getApplicationModel = (deps, opts) ->
 	# @returns {Promise}
 	#
 	# @example
-	# resin.models.application.getAppWithOwner('MyApp', 'MyUser').then(function(application) {
+	# resin.models.application.getAppByOwner('MyApp', 'MyUser').then(function(application) {
 	# 	console.log(application);
 	# });
 	###
-	exports.getAppWithOwner = (appName, owner, options = {}, callback) ->
+	exports.getAppByOwner = (appName, owner, options = {}, callback) ->
 		callback = findCallback(arguments)
 
 		appName = appName.toLowerCase()

--- a/lib/models/application.coffee
+++ b/lib/models/application.coffee
@@ -88,11 +88,7 @@ getApplicationModel = (deps, opts) ->
 							user: userId
 					, options
 
-		# TODO: It might be worth to do all these handy
-		# manipulations server side directly.
 		.map (application) ->
-			application.online_devices = filter(application.device, is_online: true).length
-			application.devices_length = application.device?.length or 0
 			normalizeApplication(application)
 			return application
 

--- a/lib/models/build.coffee
+++ b/lib/models/build.coffee
@@ -113,12 +113,6 @@ getBuildModel = (deps, opts) ->
 							'message'
 							# 'log' # We *don't* include logs by default, since it's usually huge.
 						]
-						expand:
-							user:
-								$select: [
-									'id'
-									'username'
-								]
 						orderby: 'created_at desc'
 					, options
 		.asCallback(callback)

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -767,7 +767,7 @@ getDeviceModel = (deps, opts) ->
 		.then ({ application, device }) ->
 
 			if device.device_type isnt application.device_type
-				throw new Error("Incompatible application: #{applicationNameOrId}")
+				throw new errors.ResinInvalidDeviceType("Incompatible application: #{applicationNameOrId}")
 
 			return pine.patch
 				resource: 'device'

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -149,7 +149,6 @@ getDeviceModel = (deps, opts) ->
 			resource: 'device'
 			options:
 				mergePineOptions
-					expand: 'application'
 					orderby: 'name asc'
 				, options
 
@@ -269,10 +268,7 @@ getDeviceModel = (deps, opts) ->
 				pine.get
 					resource: 'device'
 					id: uuidOrId
-					options:
-						mergePineOptions
-							expand: 'application'
-						, options
+					options: options
 				.tap (device) ->
 					if not device?
 						throw new errors.ResinDeviceNotFound(uuidOrId)
@@ -281,7 +277,6 @@ getDeviceModel = (deps, opts) ->
 					resource: 'device'
 					options:
 						mergePineOptions
-							expand: 'application'
 							filter:
 								uuid: $startswith: uuidOrId
 						, options

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -117,9 +117,6 @@ getDeviceModel = (deps, opts) ->
 		return url.resolve(dashboardUrl, "/apps/#{options.appId}/devices/#{options.deviceId}/summary")
 
 	addExtraInfo = (device) ->
-		# TODO: Move this to the server
-		device.application_name = device.application[0].app_name
-		device.dashboard_url = getDashboardUrl({ appId: device.application[0].id, deviceId: device.id })
 		normalizeDeviceOsVersion(device)
 		return device
 
@@ -389,7 +386,12 @@ getDeviceModel = (deps, opts) ->
 	# });
 	###
 	exports.getApplicationName = (uuidOrId, callback) ->
-		exports.get(uuidOrId, select: 'application_name').get('application_name').asCallback(callback)
+		exports.get uuidOrId,
+			select: 'id'
+			expand: application: $select: 'app_name'
+		.then (device) ->
+			device.application[0].app_name
+		.asCallback(callback)
 
 	###*
 	# @summary Get application container information

--- a/lib/models/environment-variables.coffee
+++ b/lib/models/environment-variables.coffee
@@ -229,9 +229,7 @@ getEnvironmentVariablesModel = (deps, opts) ->
 			return pine.get
 				resource: 'device_environment_variable'
 				options:
-					filter:
-						device: id
-					expand: 'device'
+					filter: device: id
 					orderby: 'env_var_name asc'
 		.map(fixDeviceEnvVarNameKey)
 		.asCallback(callback)
@@ -273,7 +271,6 @@ getEnvironmentVariablesModel = (deps, opts) ->
 							$any:
 								$alias: 'd',
 								$expr: d: application: id
-					expand: 'device'
 					orderby: 'env_var_name asc'
 		.map(fixDeviceEnvVarNameKey)
 		.asCallback(callback)

--- a/lib/util/index.coffee
+++ b/lib/util/index.coffee
@@ -128,8 +128,6 @@ exports.mergePineOptions = (defaults, extras) ->
 				if value?
 					if not isArray(value)
 						value = [value]
-					if !includes(value, 'id')
-						value.unshift('id')
 
 				result[option] = value
 

--- a/tests/integration/models/application.spec.coffee
+++ b/tests/integration/models/application.spec.coffee
@@ -106,14 +106,6 @@ describe 'Application Model', ->
 				resin.models.application.getAll().then (applications) =>
 					m.chai.expect(applications[0].id).to.equal(@application.id)
 
-			it 'should add a devices_length property', ->
-				resin.models.application.getAll().then (applications) ->
-					m.chai.expect(applications[0].devices_length).to.equal(0)
-
-			it 'should add an online_devices property', ->
-				resin.models.application.getAll().then (applications) ->
-					m.chai.expect(applications[0].online_devices).to.equal(0)
-
 			it 'should support arbitrary pinejs options', ->
 				resin.models.application.getAll(expand: 'user')
 				.then (applications) ->

--- a/tests/integration/models/application.spec.coffee
+++ b/tests/integration/models/application.spec.coffee
@@ -15,10 +15,10 @@ describe 'Application Model', ->
 				promise = resin.models.application.getAll()
 				m.chai.expect(promise).to.become([])
 
-		describe 'resin.models.application.getAppWithOwner()', ->
+		describe 'resin.models.application.getAppByOwner()', ->
 
 			it 'should eventually reject', ->
-				promise = resin.models.application.getAppWithOwner('testapp', 'FooBar')
+				promise = resin.models.application.getAppByOwner('testapp', 'FooBar')
 				m.chai.expect(promise).to.be.rejected
 
 		describe 'resin.models.application.hasAny()', ->
@@ -86,14 +86,14 @@ describe 'Application Model', ->
 				promise = resin.models.application.hasAny()
 				m.chai.expect(promise).to.eventually.be.true
 
-		describe 'resin.models.application.getAppWithOwner()', ->
+		describe 'resin.models.application.getAppByOwner()', ->
 
 			it 'should find the created application', ->
-				resin.models.application.getAppWithOwner('FooBar', credentials.username).then (application) =>
+				resin.models.application.getAppByOwner('FooBar', credentials.username).then (application) =>
 					m.chai.expect(application.id).to.equal(@application.id)
 
 			it 'should not find the created application with a different username', ->
-				promise = resin.models.application.getAppWithOwner('FooBar', 'test_username')
+				promise = resin.models.application.getAppByOwner('FooBar', 'test_username')
 				m.chai.expect(promise).to.eventually.reject
 
 		describe 'resin.models.application.getAll()', ->

--- a/tests/integration/models/device.spec.coffee
+++ b/tests/integration/models/device.spec.coffee
@@ -197,14 +197,6 @@ describe 'Device Model', ->
 					m.chai.expect(devices).to.have.length(1)
 					m.chai.expect(devices[0].id).to.equal(@device.id)
 
-			it 'should add an application_name property', ->
-				resin.models.device.getAll().then (devices) =>
-					m.chai.expect(devices[0].application_name).to.equal(@application.app_name)
-
-			it 'should add a dashboard_url property', ->
-				resin.models.device.getAll().then (devices) =>
-					m.chai.expect(devices[0].dashboard_url).to.equal(resin.models.device.getDashboardUrl({ appId: @application.id, deviceId: @device.id }))
-
 			it 'should support arbitrary pinejs options', ->
 				resin.models.device.getAll(select: [ 'id' ])
 				.then ([ device ]) =>
@@ -222,14 +214,6 @@ describe 'Device Model', ->
 				resin.models.device.getAllByApplication(@application.id).then (devices) =>
 					m.chai.expect(devices).to.have.length(1)
 					m.chai.expect(devices[0].id).to.equal(@device.id)
-
-			it 'should include an application_name property in the result', ->
-				resin.models.device.getAllByApplication(@application.id).then (devices) =>
-					m.chai.expect(devices[0].application_name).to.equal(@application.app_name)
-
-			it 'should add a dashboard_url property', ->
-				resin.models.device.getAllByApplication(@application.id).then (devices) =>
-					m.chai.expect(devices[0].dashboard_url).to.equal(resin.models.device.getDashboardUrl({ appId: @application.id, deviceId: @device.id }))
 
 			it 'should be rejected if the application name does not exist', ->
 				promise = resin.models.device.getAllByApplication('HelloWorldApp')
@@ -278,10 +262,6 @@ describe 'Device Model', ->
 					m.chai.expect(childDevices).to.have.length(1)
 					m.chai.expect(childDevices[0].id).to.equal(@childDevice.id)
 
-			it 'should include an application_name property in the result (with the child app name)', ->
-				resin.models.device.getAllByParentDevice(@device.id).then ([ childDevice ]) =>
-					m.chai.expect(childDevice.application_name).to.equal(@childApplication.app_name)
-
 			it 'should be empty if the parent device has no children', ->
 				promise = resin.models.device.getAllByParentDevice(@childDevice.id).then (childDevices) ->
 					m.chai.expect(childDevices).to.have.length(0)
@@ -305,14 +285,6 @@ describe 'Device Model', ->
 			it 'should be able to get the device by id', ->
 				resin.models.device.get(@device.id).then (device) =>
 					m.chai.expect(device.id).to.equal(@device.id)
-
-			it 'should add an application_name property', ->
-				resin.models.device.get(@device.id).then (device) =>
-					m.chai.expect(device.application_name).to.equal(@application.app_name)
-
-			it 'should add a dashboard_url property', ->
-				resin.models.device.get(@device.id).then (device) =>
-					m.chai.expect(device.dashboard_url).to.equal(resin.models.device.getDashboardUrl({ appId: @application.id, deviceId: @device.id }))
 
 			it 'should be rejected if the device name does not exist', ->
 				promise = resin.models.device.get('asdfghjkl')
@@ -338,14 +310,6 @@ describe 'Device Model', ->
 				resin.models.device.getByName(@device.name).then (devices) =>
 					m.chai.expect(devices).to.have.length(1)
 					m.chai.expect(devices[0].id).to.equal(@device.id)
-
-			it 'should add an application_name property', ->
-				resin.models.device.getByName(@device.name).then (devices) =>
-					m.chai.expect(devices[0].application_name).to.equal(@application.app_name)
-
-			it 'should add a dashboard_url property', ->
-				resin.models.device.getByName(@device.name).then (devices) =>
-					m.chai.expect(devices[0].dashboard_url).to.equal(resin.models.device.getDashboardUrl({ appId: @application.id, deviceId: @device.id }))
 
 			it 'should be rejected if the device does not exist', ->
 				promise = resin.models.device.getByName('HelloWorldDevice')

--- a/tests/util.spec.coffee
+++ b/tests/util.spec.coffee
@@ -42,15 +42,6 @@ describe 'Pine option merging', ->
 			skip: 4
 			orderby: 'id asc'
 
-	it 'overrides select options, but always includes id', ->
-		result = mergePineOptions
-			select: ['id', 'other']
-		,
-			select: ['app_name']
-
-		m.chai.expect(result).to.deep.equal
-			select: ['id', 'app_name']
-
 	it 'combines filter options with $and', ->
 		result = mergePineOptions
 			filter: id: 1

--- a/yarn.lock
+++ b/yarn.lock
@@ -4082,18 +4082,18 @@ resin-errors@^2.0.0:
   dependencies:
     typed-error "^0.1.0"
 
+resin-errors@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/resin-errors/-/resin-errors-2.10.0.tgz#1e24d07f0ef7d4f1edb519fad4ae4e659c1e0c66"
+  dependencies:
+    tslib "^1.7.1"
+    typed-error "^2.0.0"
+
 resin-errors@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/resin-errors/-/resin-errors-2.7.0.tgz#93ade640792107556d916df8692b5ecd97dda297"
   dependencies:
     typed-error "^0.1.0"
-
-resin-errors@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/resin-errors/-/resin-errors-2.9.0.tgz#1f5de94238d2a70c0736dca84b7bf63a144e4e50"
-  dependencies:
-    tslib "^1.7.1"
-    typed-error "^2.0.0"
 
 resin-pine@^5.0.2:
   version "5.0.2"


### PR DESCRIPTION
API v3 is an excellent excuse to bring it lots of important but breaking changes I've been putting off for a while. This PR works on the v2 API but changes behaviour by:

* Remove lots of our model add-ons 
  * These aren't currently reliable, as they mean you get different objects depending on whether you expand an object or query it directly. Really this logic should live in the API, but right now it's not strictly necessary at all (it's only used in the CLI afaik), so let's just kill it
  * This is also necessitated by the next step, which is hard to do while keeping these properties
* Stop expanding relationships by default
  * This is going to significantly reduce unnecessary load on the API, by letting the UI do much cheaper queries.
  * `getApplicationName` is now the only `expand:` left in the codebase, and I think it's reasonable and unavoidable.

This is another PR in the queue for SDK v7, so no versionbot, and merging to the `v7` branch instead of master until we're ready to ship.