### PR TITLE
Replace generateApiKey with generateProvisioningKey

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -27,7 +27,7 @@ If you feel something is missing, not clear or could be improved, please don't h
             * [.create(name, deviceType, [parentNameOrId])](#resin.models.application.create) ⇒ <code>Promise</code>
             * [.remove(nameOrId)](#resin.models.application.remove) ⇒ <code>Promise</code>
             * [.restart(nameOrId)](#resin.models.application.restart) ⇒ <code>Promise</code>
-            * [.generateApiKey(nameOrId)](#resin.models.application.generateApiKey) ⇒ <code>Promise</code>
+            * [.generateProvisioningKey(nameOrId)](#resin.models.application.generateProvisioningKey) ⇒ <code>Promise</code>
             * [.purge(appId)](#resin.models.application.purge) ⇒ <code>Promise</code>
             * [.shutdown(appId, [options])](#resin.models.application.shutdown) ⇒ <code>Promise</code>
             * [.reboot(appId, [options])](#resin.models.application.reboot) ⇒ <code>Promise</code>
@@ -274,7 +274,7 @@ resin.models.device.get(123).catch(function (error) {
         * [.create(name, deviceType, [parentNameOrId])](#resin.models.application.create) ⇒ <code>Promise</code>
         * [.remove(nameOrId)](#resin.models.application.remove) ⇒ <code>Promise</code>
         * [.restart(nameOrId)](#resin.models.application.restart) ⇒ <code>Promise</code>
-        * [.generateApiKey(nameOrId)](#resin.models.application.generateApiKey) ⇒ <code>Promise</code>
+        * [.generateProvisioningKey(nameOrId)](#resin.models.application.generateProvisioningKey) ⇒ <code>Promise</code>
         * [.purge(appId)](#resin.models.application.purge) ⇒ <code>Promise</code>
         * [.shutdown(appId, [options])](#resin.models.application.shutdown) ⇒ <code>Promise</code>
         * [.reboot(appId, [options])](#resin.models.application.reboot) ⇒ <code>Promise</code>
@@ -382,7 +382,7 @@ resin.models.device.get(123).catch(function (error) {
     * [.create(name, deviceType, [parentNameOrId])](#resin.models.application.create) ⇒ <code>Promise</code>
     * [.remove(nameOrId)](#resin.models.application.remove) ⇒ <code>Promise</code>
     * [.restart(nameOrId)](#resin.models.application.restart) ⇒ <code>Promise</code>
-    * [.generateApiKey(nameOrId)](#resin.models.application.generateApiKey) ⇒ <code>Promise</code>
+    * [.generateProvisioningKey(nameOrId)](#resin.models.application.generateProvisioningKey) ⇒ <code>Promise</code>
     * [.purge(appId)](#resin.models.application.purge) ⇒ <code>Promise</code>
     * [.shutdown(appId, [options])](#resin.models.application.shutdown) ⇒ <code>Promise</code>
     * [.reboot(appId, [options])](#resin.models.application.reboot) ⇒ <code>Promise</code>
@@ -629,13 +629,13 @@ resin.models.application.restart('MyApp', function(error) {
 	if (error) throw error;
 });
 ```
-<a name="resin.models.application.generateApiKey"></a>
+<a name="resin.models.application.generateProvisioningKey"></a>
 
-##### application.generateApiKey(nameOrId) ⇒ <code>Promise</code>
+##### application.generateProvisioningKey(nameOrId) ⇒ <code>Promise</code>
 **Kind**: static method of <code>[application](#resin.models.application)</code>  
-**Summary**: Generate an API key for a specific application  
+**Summary**: Generate a device provisioning key for a specific application  
 **Access**: public  
-**Fulfil**: <code>String</code> - api key  
+**Fulfil**: <code>String</code> - device provisioning key  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -643,21 +643,21 @@ resin.models.application.restart('MyApp', function(error) {
 
 **Example**  
 ```js
-resin.models.application.generateApiKey('MyApp').then(function(apiKey) {
-	console.log(apiKey);
+resin.models.application.generateProvisioningKey('MyApp').then(function(key) {
+	console.log(key);
 });
 ```
 **Example**  
 ```js
-resin.models.application.generateApiKey(123).then(function(apiKey) {
-	console.log(apiKey);
+resin.models.application.generateProvisioningKey(123).then(function(key) {
+	console.log(key);
 });
 ```
 **Example**  
 ```js
-resin.models.application.generateApiKey('MyApp', function(error, apiKey) {
+resin.models.application.generateProvisioningKey('MyApp', function(error, key) {
 	if (error) throw error;
-	console.log(apiKey);
+	console.log(key);
 });
 ```
 <a name="resin.models.application.purge"></a>

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -31,7 +31,6 @@ If you feel something is missing, not clear or could be improved, please don't h
             * [.purge(appId)](#resin.models.application.purge) ⇒ <code>Promise</code>
             * [.shutdown(appId, [options])](#resin.models.application.shutdown) ⇒ <code>Promise</code>
             * [.reboot(appId, [options])](#resin.models.application.reboot) ⇒ <code>Promise</code>
-            * ~~[.getApiKey(nameOrId)](#resin.models.application.getApiKey) ⇒ <code>Promise</code>~~
             * [.enableDeviceUrls(nameOrId)](#resin.models.application.enableDeviceUrls) ⇒ <code>Promise</code>
             * [.disableDeviceUrls(nameOrId)](#resin.models.application.disableDeviceUrls) ⇒ <code>Promise</code>
             * [.grantSupportAccess(nameOrId, expiryTimestamp)](#resin.models.application.grantSupportAccess) ⇒ <code>Promise</code>
@@ -279,7 +278,6 @@ resin.models.device.get(123).catch(function (error) {
         * [.purge(appId)](#resin.models.application.purge) ⇒ <code>Promise</code>
         * [.shutdown(appId, [options])](#resin.models.application.shutdown) ⇒ <code>Promise</code>
         * [.reboot(appId, [options])](#resin.models.application.reboot) ⇒ <code>Promise</code>
-        * ~~[.getApiKey(nameOrId)](#resin.models.application.getApiKey) ⇒ <code>Promise</code>~~
         * [.enableDeviceUrls(nameOrId)](#resin.models.application.enableDeviceUrls) ⇒ <code>Promise</code>
         * [.disableDeviceUrls(nameOrId)](#resin.models.application.disableDeviceUrls) ⇒ <code>Promise</code>
         * [.grantSupportAccess(nameOrId, expiryTimestamp)](#resin.models.application.grantSupportAccess) ⇒ <code>Promise</code>
@@ -388,7 +386,6 @@ resin.models.device.get(123).catch(function (error) {
     * [.purge(appId)](#resin.models.application.purge) ⇒ <code>Promise</code>
     * [.shutdown(appId, [options])](#resin.models.application.shutdown) ⇒ <code>Promise</code>
     * [.reboot(appId, [options])](#resin.models.application.reboot) ⇒ <code>Promise</code>
-    * ~~[.getApiKey(nameOrId)](#resin.models.application.getApiKey) ⇒ <code>Promise</code>~~
     * [.enableDeviceUrls(nameOrId)](#resin.models.application.enableDeviceUrls) ⇒ <code>Promise</code>
     * [.disableDeviceUrls(nameOrId)](#resin.models.application.disableDeviceUrls) ⇒ <code>Promise</code>
     * [.grantSupportAccess(nameOrId, expiryTimestamp)](#resin.models.application.grantSupportAccess) ⇒ <code>Promise</code>
@@ -730,21 +727,6 @@ resin.models.application.reboot(123, function(error) {
 	if (error) throw error;
 });
 ```
-<a name="resin.models.application.getApiKey"></a>
-
-##### ~~application.getApiKey(nameOrId) ⇒ <code>Promise</code>~~
-***Deprecated***
-
-**Kind**: static method of <code>[application](#resin.models.application)</code>  
-**Summary**: Get an API key for a specific application  
-**Access**: public  
-**Fulfil**: <code>String</code> - api key  
-**See**: [generateApiKey](#resin.models.application.generateApiKey)  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| nameOrId | <code>String</code> \| <code>Number</code> | application name (string) or id (number) |
-
 <a name="resin.models.application.enableDeviceUrls"></a>
 
 ##### application.enableDeviceUrls(nameOrId) ⇒ <code>Promise</code>

--- a/lib/models/application.coffee
+++ b/lib/models/application.coffee
@@ -24,7 +24,15 @@ filter = require('lodash/filter')
 size = require('lodash/size')
 errors = require('resin-errors')
 
-{ isId, findCallback, mergePineOptions, notFoundResponse, treatAsMissingApplication, LOCKED_STATUS_CODE } = require('../util')
+{
+	isId,
+	findCallback,
+	mergePineOptions,
+	notFoundResponse,
+	noApplicationForKeyResponse,
+	treatAsMissingApplication,
+	LOCKED_STATUS_CODE
+} = require('../util')
 { normalizeDeviceOsVersion } = require('../util/device-os-version')
 
 getApplicationModel = (deps, opts) ->
@@ -419,40 +427,39 @@ getApplicationModel = (deps, opts) ->
 		.asCallback(callback)
 
 	###*
-	# @summary Generate an API key for a specific application
-	# @name generateApiKey
+	# @summary Generate a device provisioning key for a specific application
+	# @name generateProvisioningKey
 	# @public
 	# @function
 	# @memberof resin.models.application
 	#
 	# @param {String|Number} nameOrId - application name (string) or id (number)
-	# @fulfil {String} - api key
+	# @fulfil {String} - device provisioning key
 	# @returns {Promise}
 	#
 	# @example
-	# resin.models.application.generateApiKey('MyApp').then(function(apiKey) {
-	# 	console.log(apiKey);
+	# resin.models.application.generateProvisioningKey('MyApp').then(function(key) {
+	# 	console.log(key);
 	# });
 	#
 	# @example
-	# resin.models.application.generateApiKey(123).then(function(apiKey) {
-	# 	console.log(apiKey);
+	# resin.models.application.generateProvisioningKey(123).then(function(key) {
+	# 	console.log(key);
 	# });
 	#
 	# @example
-	# resin.models.application.generateApiKey('MyApp', function(error, apiKey) {
+	# resin.models.application.generateProvisioningKey('MyApp', function(error, key) {
 	# 	if (error) throw error;
-	# 	console.log(apiKey);
+	# 	console.log(key);
 	# });
 	###
-	exports.generateApiKey = (nameOrId, callback) ->
-		# Do a full get, not just getId, because the actual api endpoint doesn't fail if the id
-		# doesn't exist. TODO: Can use getId once https://github.com/resin-io/resin-api/issues/110 is resolved
-		exports.get(nameOrId, select: 'id').then ({ id }) ->
+	exports.generateProvisioningKey = (nameOrId, callback) ->
+		getId(nameOrId).then (applicationId) ->
 			return request.send
 				method: 'POST'
-				url: "/application/#{id}/generate-api-key"
+				url: "/api-key/application/#{applicationId}/provisioning"
 				baseUrl: apiUrl
+		.catch(noApplicationForKeyResponse, treatAsMissingApplication(nameOrId))
 		.get('body')
 		.asCallback(callback)
 

--- a/lib/models/application.coffee
+++ b/lib/models/application.coffee
@@ -563,22 +563,6 @@ getApplicationModel = (deps, opts) ->
 		.asCallback(callback)
 
 	###*
-	# @summary Get an API key for a specific application
-	# @name getApiKey
-	# @public
-	# @function
-	# @memberof resin.models.application
-	#
-	# @param {String|Number} nameOrId - application name (string) or id (number)
-	# @fulfil {String} - api key
-	# @returns {Promise}
-	#
-	# @deprecated Use generateApiKey instead
-	# @see {@link resin.models.application.generateApiKey}
-	###
-	exports.getApiKey = exports.generateApiKey
-
-	###*
 	# @summary Enable device urls for all devices that belong to an application
 	# @name enableDeviceUrls
 	# @public

--- a/lib/util/index.coffee
+++ b/lib/util/index.coffee
@@ -56,6 +56,16 @@ exports.notFoundResponse =
 	code: 'ResinRequestError'
 	statusCode: 404
 
+exports.noDeviceForKeyResponse =
+	code: 'ResinRequestError'
+	statusCode: 500
+	body: 'No device found to associate with the api key'
+
+exports.noApplicationForKeyResponse =
+	code: 'ResinRequestError'
+	statusCode: 500
+	body: 'No application found to associate with the api key'
+
 exports.treatAsMissingApplication = (nameOrId) ->
 	return (err) ->
 		replacementErr = new errors.ResinApplicationNotFound(nameOrId)

--- a/tests/integration/models/application.spec.coffee
+++ b/tests/integration/models/application.spec.coffee
@@ -186,24 +186,24 @@ describe 'Application Model', ->
 				promise = resin.models.application.remove(999999)
 				m.chai.expect(promise).to.be.rejectedWith('Application not found: 999999')
 
-		describe 'resin.models.application.getApiKey()', ->
+		describe 'resin.models.application.generateProvisioningKey()', ->
 
-			it 'should be able to generate an API key by name', ->
-				resin.models.application.getApiKey(@application.app_name).then (apiKey) ->
-					m.chai.expect(_.isString(apiKey)).to.be.true
-					m.chai.expect(apiKey).to.have.length(32)
+			it 'should be able to generate a provisioning key by name', ->
+				resin.models.application.generateProvisioningKey(@application.app_name).then (key) ->
+					m.chai.expect(_.isString(key)).to.be.true
+					m.chai.expect(key).to.have.length(32)
 
 			it 'should be able to generate an API key by id', ->
-				resin.models.application.getApiKey(@application.id).then (apiKey) ->
-					m.chai.expect(_.isString(apiKey)).to.be.true
-					m.chai.expect(apiKey).to.have.length(32)
+				resin.models.application.generateProvisioningKey(@application.id).then (key) ->
+					m.chai.expect(_.isString(key)).to.be.true
+					m.chai.expect(key).to.have.length(32)
 
 			it 'should be rejected if the application name does not exist', ->
-				promise = resin.models.application.getApiKey('HelloWorldApp')
+				promise = resin.models.application.generateProvisioningKey('HelloWorldApp')
 				m.chai.expect(promise).to.be.rejectedWith('Application not found: HelloWorldApp')
 
 			it 'should be rejected if the application id does not exist', ->
-				promise = resin.models.application.getApiKey(999999)
+				promise = resin.models.application.generateProvisioningKey(999999)
 				m.chai.expect(promise).to.be.rejectedWith('Application not found: 999999')
 
 	describe 'when toggling device URLs', ->


### PR DESCRIPTION
This is already deprecated in the API, and we really shouldn't be using or exposing it here. This replaces it with provisioning keys, which are the modern alternative.

This is another fun breaking change, so another inclusion for big lovely v7.