### PR TITLE
*BREAKING*: Stop actively supporting node 4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ matrix:
       - '6'
       env:
       - 'CAN_DEPLOY=true'
-    - node_js:
-      - '4'
 before_install:
 - npm -g install npm@4
 script:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ $ npm install --save resin-sdk
 Platforms
 ---------
 
-We currently support NodeJS and the browser.
+We currently support NodeJS (6+) and the browser.
+
 The following features are node-only:
 - OS image streaming download (`resin.models.os.download`),
 - resin settings client (`resin.settings`).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,13 +14,13 @@ matrix:
 # what combinations to test
 environment:
   matrix:
-    - nodejs_version: 6
+    - nodejs_version: 8
       RESINTEST_EMAIL: 'test2+juan@resin.io'
       RESINTEST_USERNAME: 'test2_juan'
       RESINTEST_USERID: 5616
       RESINTEST_REGISTER_EMAIL: 'test2+register+juan@resin.io'
       RESINTEST_REGISTER_USERNAME: 'test2_register_juan'
-    - nodejs_version: 4
+    - nodejs_version: 6
       RESINTEST_EMAIL: 'test3+juan@resin.io'
       RESINTEST_USERNAME: 'test3_juan'
       RESINTEST_USERID: 8717

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
   },
   "author": "Juan Cruz Viotti <juan@resin.io>",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=6.0"
+  },
   "devDependencies": {
     "browserify": "^14.3.0",
     "catch-uncommitted": "^1.0.0",


### PR DESCRIPTION
Another breaking change for the SDK v7 branch.

Connects to #415, and comes on top of #416, which adds basic node 8 tests to travis.