### PR TITLE
Move to API v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ node_modules
 
 
 .DS_Store
-.env
+.env*
 .vscode
 
 # Ignore all build output

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -3670,7 +3670,6 @@ startup and before any calls to `fromSharedOptions()` are made.
 resin.setSharedOptions({
 	apiUrl: 'https://api.resin.io/',
 	imageMakerUrl: 'https://img.resin.io/',
-	apiVersion: 'v2',
 	isBrowser: true,
 });
 ```

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -233,7 +233,7 @@ in the SDK.
 resin.pine.get({
 	resource: 'build/$count',
 	options: {
-		filter: { application: applicationId }
+		filter: { belongs_to__application: applicationId }
 	}
 });
 ```

--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ var resin = require('resin-sdk')({
 
 Where the factory method accepts the following options:
 * `apiUrl`, string, *optional*, is the resin.io API url. Defaults to `https://api.resin.io/`,
-* `apiVersion`, string, *optional*, is the version of the API to talk to, like `v2`. Defaults to the current stable version: `v2`,
 * `apiKey`, string, *optional*, is the API key to make the requests with,
 * `imageMakerUrl`, string, *optional*, is the resin.io image maker url. Defaults to `https://img.resin.io/`,
 * `dataDirectory`, string, *optional*, *ignored in the browser*, is the directory where the user settings are stored, normally retrieved like `require('resin-settings-client').get('dataDirectory')`. Defaults to `$HOME/.resin`,

--- a/lib/models/application.coffee
+++ b/lib/models/application.coffee
@@ -55,8 +55,8 @@ getApplicationModel = (deps, opts) ->
 	exports._getId = getId
 
 	normalizeApplication = (application) ->
-		if isArray(application.device)
-			forEach application.device, (device) ->
+		if isArray(application.owns__device)
+			forEach application.owns__device, (device) ->
 				normalizeDeviceOsVersion(device)
 		return application
 
@@ -354,7 +354,7 @@ getApplicationModel = (deps, opts) ->
 				throw new errors.ResinDiscontinuedDeviceType(deviceType)
 
 			extraOptions = if parentApplication
-				application: parentApplication.id
+				depends_on__application: parentApplication.id
 			else {}
 
 			return pine.post
@@ -598,7 +598,7 @@ getApplicationModel = (deps, opts) ->
 					is_web_accessible: true
 				options:
 					filter:
-						application: id
+						belongs_to__application: id
 		.asCallback(callback)
 
 	###*
@@ -630,7 +630,7 @@ getApplicationModel = (deps, opts) ->
 					is_web_accessible: false
 				options:
 					filter:
-						application: id
+						belongs_to__application: id
 		.asCallback(callback)
 
 	###*
@@ -663,7 +663,7 @@ getApplicationModel = (deps, opts) ->
 			return pine.patch
 				resource: 'application'
 				id: applicationId
-				body: support_expiry_date: expiryTimestamp
+				body: is_accessible_by_support_until__date: expiryTimestamp
 		.catch(notFoundResponse, treatAsMissingApplication(nameOrId))
 		.asCallback(callback)
 
@@ -693,7 +693,7 @@ getApplicationModel = (deps, opts) ->
 			return pine.patch
 				resource: 'application'
 				id: applicationId
-				body: support_expiry_date: null
+				body: is_accessible_by_support_until__date: null
 		.catch(notFoundResponse, treatAsMissingApplication(nameOrId))
 		.asCallback(callback)
 

--- a/lib/models/build.coffee
+++ b/lib/models/build.coffee
@@ -98,7 +98,7 @@ getBuildModel = (deps, opts) ->
 				options:
 					mergePineOptions
 						filter:
-							application: id
+							belongs_to__application: id
 						select: [
 							'id'
 							'created_at'

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -198,7 +198,7 @@ getDeviceModel = (deps, opts) ->
 
 		applicationModel().get(nameOrId, select: 'id').then ({ id }) ->
 			exports.getAll(mergePineOptions(
-				filter: application: id
+				filter: belongs_to__application: id
 				options
 			), callback)
 
@@ -235,7 +235,7 @@ getDeviceModel = (deps, opts) ->
 
 		exports.get(parentUuidOrId, select: 'id').then ({ id }) ->
 			exports.getAll(mergePineOptions(
-				filter: device: id
+				filter: is_managed_by__device: id
 				options
 			), callback)
 
@@ -393,9 +393,9 @@ getDeviceModel = (deps, opts) ->
 	exports.getApplicationName = (uuidOrId, callback) ->
 		exports.get uuidOrId,
 			select: 'id'
-			expand: application: $select: 'app_name'
+			expand: belongs_to__application: $select: 'app_name'
 		.then (device) ->
-			device.application[0].app_name
+			device.belongs_to__application[0].app_name
 		.asCallback(callback)
 
 	###*
@@ -428,7 +428,7 @@ getDeviceModel = (deps, opts) ->
 	exports.getApplicationInfo = (uuidOrId, callback) ->
 		exports.get(uuidOrId).then (device) ->
 			ensureSupervisorCompatibility(device.supervisor_version, MIN_SUPERVISOR_APPS_API).then ->
-				appId = device.application[0].id
+				appId = device.belongs_to__application[0].id
 				return request.send
 					method: 'POST'
 					url: "/supervisor/v1/apps/#{appId}"
@@ -782,7 +782,7 @@ getDeviceModel = (deps, opts) ->
 			return pine.patch
 				resource: 'device'
 				body:
-					application: application.id
+					belongs_to__application: application.id
 				options:
 					filter:
 						uuid: device.uuid
@@ -819,7 +819,7 @@ getDeviceModel = (deps, opts) ->
 	exports.startApplication = (uuidOrId, callback) ->
 		exports.get(uuidOrId).then (device) ->
 			ensureSupervisorCompatibility(device.supervisor_version, MIN_SUPERVISOR_APPS_API).then ->
-				appId = device.application[0].id
+				appId = device.belongs_to__application[0].id
 				return request.send
 					method: 'POST'
 					url: "/supervisor/v1/apps/#{appId}/start"
@@ -862,7 +862,7 @@ getDeviceModel = (deps, opts) ->
 	exports.stopApplication = (uuidOrId, callback) ->
 		exports.get(uuidOrId).then (device) ->
 			ensureSupervisorCompatibility(device.supervisor_version, MIN_SUPERVISOR_APPS_API).then ->
-				appId = device.application[0].id
+				appId = device.belongs_to__application[0].id
 				return request.send
 					method: 'POST'
 					url: "/supervisor/v1/apps/#{appId}/stop"
@@ -989,7 +989,7 @@ getDeviceModel = (deps, opts) ->
 				baseUrl: apiUrl
 				body:
 					deviceId: device.id
-					appId: device.application[0].id
+					appId: device.belongs_to__application[0].id
 					data:
 						force: Boolean(options.force)
 			.catch (err) ->
@@ -1031,9 +1031,9 @@ getDeviceModel = (deps, opts) ->
 				baseUrl: apiUrl
 				body:
 					deviceId: device.id
-					appId: device.application[0].id
+					appId: device.belongs_to__application[0].id
 					data:
-						appId: device.application[0].id
+						appId: device.belongs_to__application[0].id
 			.catch (err) ->
 				if err.statusCode == LOCKED_STATUS_CODE
 					throw new errors.ResinSupervisorLockedError()
@@ -1078,7 +1078,7 @@ getDeviceModel = (deps, opts) ->
 				baseUrl: apiUrl
 				body:
 					deviceId: device.id
-					appId: device.application[0].id
+					appId: device.belongs_to__application[0].id
 					data:
 						force: Boolean(options.force)
 		.asCallback(callback)
@@ -1530,7 +1530,7 @@ getDeviceModel = (deps, opts) ->
 				baseUrl: apiUrl
 				data:
 					deviceId: device.id
-					appId: device.application[0].id
+					appId: device.belongs_to__application[0].id
 		.get('body')
 		.asCallback(callback)
 
@@ -1567,7 +1567,7 @@ getDeviceModel = (deps, opts) ->
 				baseUrl: apiUrl
 				data:
 					deviceId: device.id
-					appId: device.application[0].id
+					appId: device.belongs_to__application[0].id
 		.get('body')
 		.asCallback(callback)
 
@@ -1604,7 +1604,7 @@ getDeviceModel = (deps, opts) ->
 				body:
 					method: 'GET'
 					deviceId: device.id
-					appId: device.application[0].id
+					appId: device.belongs_to__application[0].id
 		.asCallback(callback)
 
 	###*
@@ -1664,7 +1664,7 @@ getDeviceModel = (deps, opts) ->
 			return pine.patch
 				resource: 'device'
 				id: id
-				body: support_expiry_date: expiryTimestamp
+				body: is_accessible_by_support_until__date: expiryTimestamp
 		.asCallback(callback)
 
 	###*
@@ -1693,7 +1693,7 @@ getDeviceModel = (deps, opts) ->
 			return pine.patch
 				resource: 'device'
 				id: id
-				body: support_expiry_date: null
+				body: is_accessible_by_support_until__date: null
 		.asCallback(callback)
 
 	###*

--- a/lib/models/environment-variables.coffee
+++ b/lib/models/environment-variables.coffee
@@ -270,7 +270,7 @@ getEnvironmentVariablesModel = (deps, opts) ->
 						device:
 							$any:
 								$alias: 'd',
-								$expr: d: application: id
+								$expr: d: belongs_to__application: id
 					orderby: 'env_var_name asc'
 		.map(fixDeviceEnvVarNameKey)
 		.asCallback(callback)

--- a/lib/resin.coffee
+++ b/lib/resin.coffee
@@ -81,7 +81,7 @@ getSdk = (opts = {}) ->
 		isBrowser: window?
 
 	# You cannot externally set the API version (as SDK implementation depends on it)
-	opts.apiVersion = 'v2'
+	opts.apiVersion = 'v3'
 
 	if opts.isBrowser
 		settings =
@@ -207,7 +207,7 @@ getSdk = (opts = {}) ->
 	# resin.pine.get({
 	#	resource: 'build/$count',
 	#	options: {
-	#		filter: { application: applicationId }
+	#		filter: { belongs_to__application: applicationId }
 	#	}
 	# });
 	###

--- a/lib/resin.coffee
+++ b/lib/resin.coffee
@@ -78,8 +78,10 @@ getSdk = (opts = {}) ->
 	defaults opts,
 		apiUrl: 'https://api.resin.io/'
 		imageMakerUrl: 'https://img.resin.io/'
-		apiVersion: 'v2'
 		isBrowser: window?
+
+	# You cannot externally set the API version (as SDK implementation depends on it)
+	opts.apiVersion = 'v2'
 
 	if opts.isBrowser
 		settings =
@@ -255,7 +257,6 @@ getSdk = (opts = {}) ->
 # resin.setSharedOptions({
 # 	apiUrl: 'https://api.resin.io/',
 # 	imageMakerUrl: 'https://img.resin.io/',
-# 	apiVersion: 'v2',
 # 	isBrowser: true,
 # });
 ###

--- a/tests/integration/models/application.spec.coffee
+++ b/tests/integration/models/application.spec.coffee
@@ -40,7 +40,7 @@ describe 'Application Model', ->
 				.then ->
 					resin.models.application.getAll()
 				.then ([ parentApplication, childApplication ]) ->
-					m.chai.expect(childApplication.application.__id).to.equal(parentApplication.id)
+					m.chai.expect(childApplication.depends_on__application.__id).to.equal(parentApplication.id)
 
 			it 'should be rejected if the device type is invalid', ->
 				promise = resin.models.application.create('FooBar', 'foobarbaz')
@@ -256,7 +256,7 @@ describe 'Application Model', ->
 				.then =>
 					resin.models.application.get(@application.id)
 				.then (app) ->
-					Date.parse(app.support_expiry_date)
+					Date.parse(app.is_accessible_by_support_until__date)
 
 				m.chai.expect(promise).to.eventually.equal(expiryTime)
 
@@ -269,7 +269,7 @@ describe 'Application Model', ->
 				.then =>
 					resin.models.application.get(@application.id)
 				.then (app) ->
-					app.support_expiry_date
+					app.is_accessible_by_support_until__date
 
 				m.chai.expect(promise).to.eventually.equal(null)
 

--- a/tests/integration/models/device.spec.coffee
+++ b/tests/integration/models/device.spec.coffee
@@ -244,11 +244,11 @@ describe 'Device Model', ->
 					resin.pine.post
 						resource: 'device'
 						body:
-							user: userId
-							application: @childApplication.id
+							belongs_to__user: userId
+							belongs_to__application: @childApplication.id
 							device_type: @childApplication.device_type
 							uuid: resin.models.device.generateUniqueKey()
-							device: @device.id
+							is_managed_by__device: @device.id
 				.then (device) =>
 					@childDevice = device
 
@@ -738,8 +738,8 @@ describe 'Device Model', ->
 				promise = resin.models.device.grantSupportAccess(@device.id, expiryTimestamp)
 				.then =>
 					resin.models.device.get(@device.id)
-				.then ({ support_expiry_date }) ->
-					Date.parse(support_expiry_date)
+				.then ({ is_accessible_by_support_until__date }) ->
+					Date.parse(is_accessible_by_support_until__date)
 
 				m.chai.expect(promise).to.eventually.equal(expiryTimestamp)
 
@@ -750,8 +750,8 @@ describe 'Device Model', ->
 					resin.models.device.revokeSupportAccess(@device.id)
 				.then =>
 					resin.models.device.get(@device.id)
-				.then ({ support_expiry_date }) ->
-					m.chai.expect(support_expiry_date).to.be.null
+				.then ({ is_accessible_by_support_until__date }) ->
+					m.chai.expect(is_accessible_by_support_until__date).to.be.null
 
 	describe 'given a single application with a device id whose shorter uuid is only numbers', ->
 

--- a/tests/integration/setup.coffee
+++ b/tests/integration/setup.coffee
@@ -23,7 +23,6 @@ else
 		dataDirectory: settings.get('dataDirectory')
 
 _.assign opts,
-	apiVersion: 'v2'
 	apiKey: null
 	isBrowser: IS_BROWSER,
 	retries: 3


### PR DESCRIPTION
Woo hoo - this moves the SDK to the new pine 5/api v3, updating all the relationships along the way, and hopefully finishing up 7.0.0. This has been made easier by the previous PRs removing lots of relationship logic entirely, but there's still quite a few left. 

Note that while this doesn't break an enormous amount of code internally, it will break a huge amount of user code - anything that tries to follow relationships between models is going to have to be updated.

I'd definitely like your review on this to confirm before I merge @Page-, just in case I've missed something obvious.

Once this is done, I'm going to merge this into the v7 branch, do a last little bit of manual testing to double check things, and then I'm going to open a PR to master to look at, and get versionbot to do a 7.0.0 there release with everything in.