### PR TITLE
Re-enable test disabled due to a proxy bug

### DIFF
--- a/tests/integration/models/device.spec.coffee
+++ b/tests/integration/models/device.spec.coffee
@@ -628,7 +628,7 @@ describe 'Device Model', ->
 					promise = resin.models.device.getDeviceUrl(@device.id)
 					m.chai.expect(promise).to.eventually.match(/[a-z0-9]{62}/)
 
-				xit 'should eventually be an absolute url given a uuid', ->
+				it 'should eventually be an absolute url given a uuid', ->
 					resin.models.device.getDeviceUrl(@device.uuid)
 					.then(makeRequest)
 					.then (response) ->


### PR DESCRIPTION
The fix for this (https://github.com/resin-io/resin-proxy/issues/134) has now been released to production.

This undoes #435 (and in a similar way, should be merged no-checks'd)