### PR TITLE
Read logs from the API, for modern supervisors

### DIFF
--- a/lib/logs.coffee
+++ b/lib/logs.coffee
@@ -63,7 +63,7 @@ getLogs = (deps, opts) ->
 
 			pubNubKeys: configModel.getPubNubKeys()
 
-	usesApiLogs = Promise.method (device) ->
+	usesApiLogs = (device) ->
 		# If don't know the supervisor, assume it's a new one to start with
 		hasNewSupervisor = !device.supervisor_version or rSemver.satisfies(
 			device.supervisor_version,

--- a/lib/logs.coffee
+++ b/lib/logs.coffee
@@ -119,21 +119,22 @@ getLogs = (deps, opts) ->
 			imageInstallLogs = flatMap(device.image_install, (install) ->
 				serviceId = install.image[0].is_a_build_of__service[0].id
 
-				install.owns__image_install_log.reverse().map (logMessage) ->
-					message: logMessage.message
-					isSystem: logMessage.is_system
-					timestamp: moment(logMessage.device_timestamp).valueOf()
-					serviceId: serviceId
+				install.owns__image_install_log.reverse().map (msg) ->
+					formatLogMessage(msg, serviceId)
 			)
 
-			return deviceLogs.map (logMessage) ->
-				message: logMessage.message
-				isSystem: logMessage.is_system
-				timestamp: moment(logMessage.device_timestamp).valueOf()
-				serviceId: null
+			return deviceLogs.map (msg) ->
+				formatLogMessage(msg, null)
 			.concat(imageInstallLogs)
 			.sort (a, b) ->
 				a.timestamp - b.timestamp
+
+	formatLogMessage = (logMessage, serviceId) ->
+		message: logMessage.message
+		isSystem: logMessage.is_system
+		isStdErr: logMessage.is_stderr
+		timestamp: moment(logMessage.device_timestamp).valueOf()
+		serviceId: serviceId
 
 	subscribeToApiLogs = Promise.method (device) ->
 		emitter = new EventEmitter()

--- a/lib/logs.coffee
+++ b/lib/logs.coffee
@@ -151,6 +151,9 @@ getLogs = (deps, opts) ->
 					# This means we unsubscribed while waiting for the API
 					return
 
+				if logs.length
+					latestLogTime = logs[logs.length - 1].timestamp
+
 				logs.forEach (log) ->
 					emitter.emit('line', log)
 			.catch (e) ->

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "resin-pine": "^6.0.0",
     "resin-register-device": "^5.0.0",
     "resin-request": "^9.0.0",
+    "resin-semver": "^1.2.1",
     "resin-settings-client": "^3.5.2",
     "semver": "^5.3.0"
   },

--- a/tests/integration/logs.spec.coffee
+++ b/tests/integration/logs.spec.coffee
@@ -22,8 +22,8 @@ createContainerLog = (message, imageInstall, deviceKey, options = {}) ->
 		body: Object.assign
 			belongs_to__image_install: imageInstall.id
 			device_timestamp: Date.now()
-			stderr: false
-			system: false
+			is_stderr: false
+			is_system: false
 			message: 'hi!'
 		, options, { message }
 		passthrough:
@@ -90,7 +90,9 @@ describe 'Logs', ->
 			beforeEach ->
 				createLog('Test message 1', @device, @deviceKey)
 				.then =>
-					createLog('Test message 2', @device, @deviceKey)
+					createLog 'Test message 2', @device, @deviceKey,
+						is_system: true
+						is_stderr: true
 
 			describe '.history', ->
 
@@ -99,8 +101,12 @@ describe 'Logs', ->
 					.then (history) ->
 						m.chai.expect(history).to.deep.match([
 							message: 'Test message 1'
+							isSystem: false
+							isStdErr: false
 						,
 							message: 'Test message 2'
+							isSystem: true
+							isStdErr: true
 						])
 
 				it 'should limit the logs by the count given', ->

--- a/tests/integration/logs.spec.coffee
+++ b/tests/integration/logs.spec.coffee
@@ -62,15 +62,26 @@ describe 'Logs', ->
 				it 'should emit new messages', ->
 					resin.logs.subscribe(@device.uuid)
 					.then (subscription) =>
-						new Promise (resolve, reject) =>
-							subscription.on('line', resolve)
-							subscription.on('error', reject)
+						messages = []
 
-							createLog('New message', @device, @deviceKey)
-						.timeout(2000)
-						.then (logMessage) ->
-							m.chai.expect(logMessage).to.deep.match
-								message: 'New message'
+						subscription.on('line', (msg) -> messages.push(msg))
+
+						createLog('Message 1', @device, @deviceKey)
+						.delay(1500)
+						.then =>
+							m.chai.expect(messages).to.have.lengthOf(1)
+							m.chai.expect(messages).to.deep.match [
+								message: 'Message 1'
+							]
+							createLog('Message 2', @device, @deviceKey)
+						.delay(1500)
+						.then ->
+							m.chai.expect(messages).to.have.lengthOf(2)
+							m.chai.expect(messages).to.deep.match [
+								message: 'Message 1'
+							,
+								message: 'Message 2'
+							]
 						.finally ->
 							subscription.unsubscribe()
 

--- a/tests/integration/logs.spec.coffee
+++ b/tests/integration/logs.spec.coffee
@@ -1,0 +1,169 @@
+_ = require('lodash')
+m = require('mochainon')
+Promise = require('bluebird')
+
+{ resin, givenLoggedInUser, givenMulticontainerApplication } = require('./setup')
+
+createLog = (message, device, deviceKey, options = {}) ->
+	resin.pine.post
+		resource: 'device_log'
+		body: Object.assign
+			belongs_to__device: device.id
+			device_timestamp: Date.now()
+			stderr: false
+			system: false
+		, options, { message }
+		passthrough:
+			apiKey: deviceKey
+
+createContainerLog = (message, imageInstall, deviceKey, options = {}) ->
+	resin.pine.post
+		resource: 'image_install_log'
+		body: Object.assign
+			belongs_to__image_install: imageInstall.id
+			device_timestamp: Date.now()
+			stderr: false
+			system: false
+			message: 'hi!'
+		, options, { message }
+		passthrough:
+			apiKey: deviceKey
+
+describe 'Logs', ->
+
+	givenLoggedInUser()
+
+	describe 'given an application with a api-logging device', ->
+
+		givenMulticontainerApplication()
+
+		beforeEach ->
+			Promise.all [
+				# Make sure our device looks api-log compatible
+				resin.pine.patch
+					resource: 'device'
+					body:
+						supervisor_version: '7.0.0'
+			,
+				resin.models.device.generateDeviceKey(@device.id)
+				.then (key) =>
+					@deviceKey = key
+			]
+
+		describe 'given no logs present', ->
+
+			describe '.history', ->
+
+				it 'should return no history', ->
+					resin.logs.history(@device.uuid)
+					.then (history) ->
+						m.chai.expect(history).to.deep.equal([])
+
+				it 'should emit new messages', ->
+					resin.logs.subscribe(@device.uuid)
+					.then (subscription) =>
+						new Promise (resolve, reject) =>
+							subscription.on('line', resolve)
+							subscription.on('error', reject)
+
+							createLog('New message', @device, @deviceKey)
+						.timeout(2000)
+						.then (logMessage) ->
+							m.chai.expect(logMessage).to.deep.match
+								message: 'New message'
+						.finally ->
+							subscription.unsubscribe()
+
+		describe 'given pre-existing device logs', ->
+
+			beforeEach ->
+				createLog('Test message 1', @device, @deviceKey)
+				.then =>
+					createLog('Test message 2', @device, @deviceKey)
+
+			describe '.history', ->
+
+				it 'should return the logs', ->
+					resin.logs.history(@device.uuid)
+					.then (history) ->
+						m.chai.expect(history).to.deep.match([
+							message: 'Test message 1'
+						,
+							message: 'Test message 2'
+						])
+
+				it 'should limit the logs by the count given', ->
+					resin.logs.history(@device.uuid, { count: 1 })
+					.then (history) ->
+						m.chai.expect(history).to.deep.match([
+							message: 'Test message 2'
+						])
+
+			describe '.subscribe', ->
+
+				it 'should emit new messages', ->
+					resin.logs.subscribe(@device.uuid)
+					.then (subscription) =>
+						new Promise (resolve, reject) =>
+							subscription.on('line', resolve)
+							subscription.on('error', reject)
+
+							createLog('New message', @device, @deviceKey)
+						.timeout(2000)
+						.then (logMessage) ->
+							m.chai.expect(logMessage).to.deep.match
+								message: 'New message'
+						.finally ->
+							subscription.unsubscribe()
+
+		describe 'given preexisting container logs', ->
+
+			beforeEach ->
+				createContainerLog('Test message 1', @newWebInstall, @deviceKey)
+				.then =>
+					createContainerLog('Test message 2', @newDbInstall, @deviceKey)
+				.then =>
+					createContainerLog('Test message 3', @newWebInstall, @deviceKey)
+
+			describe '.history', ->
+
+				it 'should return the logs', ->
+					resin.logs.history(@device.uuid)
+					.then (history) =>
+						m.chai.expect(history).to.deep.match([
+							message: 'Test message 1'
+							serviceId: @webService.id
+						,
+							message: 'Test message 2'
+							serviceId: @dbService.id
+						,
+							message: 'Test message 3'
+							serviceId: @webService.id
+						])
+
+				it 'should limit the logs by the count given', ->
+					resin.logs.history(@device.uuid, { count: 1 })
+					.then (history) ->
+						m.chai.expect(history).to.deep.match([
+							message: 'Test message 2'
+						])
+
+			describe '.subscribe', ->
+
+				it 'should emit new messages', ->
+					resin.logs.subscribe(@device.uuid)
+					.then (subscription) =>
+						new Promise (resolve, reject) =>
+							subscription.on('line', resolve)
+							subscription.on('error', reject)
+
+							createContainerLog('New message', @newWebInstall, @deviceKey)
+						.timeout(2000)
+						.then (logMessage) ->
+							m.chai.expect(logMessage).to.deep.match
+								message: 'New message'
+						.finally ->
+							subscription.unsubscribe()
+
+
+

--- a/typings/resin-sdk.d.ts
+++ b/typings/resin-sdk.d.ts
@@ -430,6 +430,7 @@ declare namespace ResinSdk {
 	interface LogMessage {
 		message: string;
 		isSystem: boolean;
+		isStdErr: boolean | null;
 		timestamp: number | null;
 		serviceId: number | null;
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,13 +14,31 @@
   version "3.5.19"
   resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.19.tgz#1a47308819ac2d1d6d1ca4f5d800ac84924100de"
 
+"@types/chai@^4.0.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.1.1.tgz#15f1257fab17b7acb9c413f9f88d3d87f834d11e"
+
 "@types/jwt-decode@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@types/jwt-decode/-/jwt-decode-2.2.1.tgz#afdf5c527fcfccbd4009b5fd02d1e18241f2d2f2"
 
+"@types/lodash.memoize@^4.1.2":
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/@types/lodash.memoize/-/lodash.memoize-4.1.3.tgz#7d3cd9cb9cd87085c9ee8a1679991180e6dae3cc"
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.93"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.93.tgz#a6d2a1e1601a3c29196f38ef1990b68a9afa1e1c"
+
 "@types/lodash@^4.14.85":
   version "4.14.85"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.85.tgz#a16fbf942422f6eca5622b6910492c496c35069b"
+
+"@types/mocha@^2.2.41":
+  version "2.2.46"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.46.tgz#b04713f7759d1cf752effdaae7b3969e285ebc16"
 
 "@types/node@^8.0.19":
   version "8.5.5"
@@ -29,6 +47,10 @@
 "@types/node@^8.0.53":
   version "8.0.53"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.53.tgz#396b35af826fa66aad472c8cb7b8d5e277f4e6d8"
+
+"@types/semver@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.4.0.tgz#f3658535af7f1f502acd6da7daf405ffeb1f7ee4"
 
 JSONStream@^1.0.3:
   version "1.3.1"
@@ -3374,6 +3396,10 @@ lodash.mapvalues@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c"
 
+lodash.memoize@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+
 lodash.memoize@~3.0.3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-3.0.4.tgz#2dcbd2c287cbc0a55cc42328bd0c736150d53e3f"
@@ -4713,6 +4739,17 @@ resin-request@^9.0.0:
     qs "^6.3.0"
     resin-errors "^2.7.0"
     rindle "^1.3.1"
+
+resin-semver@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/resin-semver/-/resin-semver-1.2.1.tgz#aed5a975e9bd13bd7c33f9006197e5c9c1470f5a"
+  dependencies:
+    "@types/chai" "^4.0.1"
+    "@types/lodash.memoize" "^4.1.2"
+    "@types/mocha" "^2.2.41"
+    "@types/semver" "^5.4.0"
+    lodash.memoize "^4.1.2"
+    semver "^5.3.0"
 
 resin-settings-client@^3.5.2:
   version "3.5.2"


### PR DESCRIPTION
This is separate, rather than being on the multicontainer branch immediately, because it depends on @flesler's API changes being available in the API (specifically `image_install_logs`), so won't currently work against the API multicontainer branch.

This can be merged (manually, not with versionbot!) once that's in, and it's a non-breaking change