### PR TITLE
Stop SDK tests checking for (removed) version parameter in config.json

### DIFF
--- a/tests/integration/models/os.spec.coffee
+++ b/tests/integration/models/os.spec.coffee
@@ -280,7 +280,6 @@ describe 'OS model', ->
 					eventuallyExpectProperty(promise, 'appUpdatePollInterval').that.equals(configOptions.appUpdatePollInterval * 60 * 1000)
 					eventuallyExpectProperty(promise, 'wifiKey').that.equals(configOptions.wifiKey)
 					eventuallyExpectProperty(promise, 'wifiSsid').that.equals(configOptions.wifiSsid)
-					eventuallyExpectProperty(promise, 'version').that.equals(configOptions.version)
 					eventuallyExpectProperty(promise, 'files')
 						.that.has.property('network/network.config')
 						.that.includes("#{configOptions.ip}/#{configOptions.netmask}/#{configOptions.gateway}")


### PR DESCRIPTION
https://github.com/resin-io/resin-api/issues/1003 has just reached production. This removes the `version` field in API-generated config.json downloads. Unfortunately, the tests unnecessarily expect that field - this tiny PR removes that.

I've just done this for the MC branch for now, not master, but we can backport to master too easily later, if we need to.