### PR TITLE
Add transitional support for the name field on app & device env vars

### DIFF
--- a/typings/resin-sdk.d.ts
+++ b/typings/resin-sdk.d.ts
@@ -546,10 +546,9 @@ declare namespace ResinSdk {
 		application: NavigationResource<Application>;
 	}
 
-	interface SecondaryEnvironmentVariableBase {
-		id: number;
-		env_var_name: string;
-		value: string;
+	interface SecondaryEnvironmentVariableBase extends EnvironmentVariableBase {
+		/** @deprecated */
+		env_var_name?: string;
 	}
 
 	interface ApplicationEnvironmentVariable


### PR DESCRIPTION
Or we could just drop it completely after the API reaches prod (or maybe right away).
Resolves: #510
Change-Type: patch