### PR TITLE
Add billing addon plan addons to the SDK types

### DIFF
--- a/typings/resin-sdk.d.ts
+++ b/typings/resin-sdk.d.ts
@@ -374,11 +374,33 @@ declare namespace ResinSdk {
 		billing: BillingPlanBillingInfo;
 		intervalUnit?: string;
 		intervalLength?: string;
+		addonPlan?: BillingAddonPlanInfo;
+	}
+
+	interface BillingAddonPlanInfo {
+		code: string;
+		currentPeriodEndDate?: string;
+		billing: BillingPlanBillingInfo;
+
+		addOns: Array<{
+			code: string;
+			unitCostCents?: string;
+			quantity?: string;
+		}>;
 	}
 
 	interface BillingPlanBillingInfo {
 		currency: string;
 		currencySymbol?: string;
+		totalCostCents: string;
+
+		charges: Array<{
+			itemType: string;
+			name: string;
+			code: string;
+			unitCostCents: string;
+			quantity: string;
+		}>;
 	}
 
 	interface InvoiceInfo {


### PR DESCRIPTION
Fixes #521 
Needs to wait until https://github.com/resin-io/resin-api/pull/1060 (API 5.5.7) hits production.

Change-Type: patch