### PR TITLE
Document getConfig's limitations when using API keys

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2945,6 +2945,12 @@ resin.models.os.download('raspberry-pi', function(error, stream) {
 <a name="resin.models.os.getConfig"></a>
 
 ##### os.getConfig(nameOrId, options) ⇒ <code>Promise</code>
+Builds the config.json for a device in the given application, with the given
+options.
+
+Note that an OS version is required. For versions < 2.7.8, config
+generation is only supported when using a session token, not an API key.
+
 **Kind**: static method of [<code>os</code>](#resin.models.os)  
 **Summary**: Get an applications config.json  
 **Access**: public  

--- a/lib/models/os.coffee
+++ b/lib/models/os.coffee
@@ -321,6 +321,13 @@ getOsModel = (deps, opts) ->
 	# @function
 	# @memberof resin.models.os
 	#
+	# @description
+	# Builds the config.json for a device in the given application, with the given
+	# options.
+	#
+	# Note that an OS version is required. For versions < 2.7.8, config
+	# generation is only supported when using a session token, not an API key.
+	#
 	# @param {String|Number} nameOrId - application name (string) or id (number).
 	# @param {Object} options - OS configuration options to use.
 	# @param {String} options.version - Required: the OS version of the image.


### PR DESCRIPTION
Wrapping up the last few extra things we should include in MC, and I spotted this one.

Fixes #526 