### PR TITLE
typings: Update to be compatible with TS 2.9

### DIFF
--- a/typings/pinejs-client-core.d.ts
+++ b/typings/pinejs-client-core.d.ts
@@ -1,3 +1,27 @@
+// backwards compatible alternative for: Extract<keyof T, string>
+type StringKeyof<T> = keyof T & string;
+
+export interface WithId {
+	id: number;
+}
+
+export interface PineDeferred {
+	__id: number;
+}
+
+/**
+ * When not selected-out holds a deferred.
+ * When expanded hold an array with a single element.
+ */
+export type NavigationResource<T = WithId> = T[] | PineDeferred;
+
+/**
+ * When expanded holds an array, otherwise the property is not present.
+ * Selecting is not suggested,
+ * in that case it holds a deferred to the original resource.
+ */
+export type ReverseNavigationResource<T = WithId> = T[] | undefined;
+
 // based on https://github.com/resin-io/pinejs-client-js/blob/master/core.d.ts
 
 type RawFilter =
@@ -36,6 +60,37 @@ type FilterExpressions<T> = {
 
 type Filter<T> = ResourceObjFilter<T> & FilterExpressions<T>;
 
-type BaseExpandFor<T> = { [k in keyof T]?: object } | keyof T;
+type BaseExpandFor<T> = { [k in keyof T]?: object } | StringKeyof<T>;
 
 export type Expand<T> = BaseExpandFor<T> | Array<BaseExpandFor<T>>;
+
+export interface PineOptions {
+	$select?: string[] | string | '*';
+	$filter?: object;
+	$expand?: object | string;
+	$orderby?: OrderBy;
+	$top?: number;
+	$skip?: number;
+}
+
+export interface PineOptionsFor<T> extends PineOptions {
+	$select?: Array<StringKeyof<T>> | StringKeyof<T> | '*';
+	$filter?: Filter<T>;
+	$expand?: Expand<T>;
+}
+
+export interface PineParams {
+	resource: string;
+	id?: number;
+	body?: object;
+	options?: PineOptions;
+}
+
+export interface PineParamsFor<T> extends PineParams {
+	body?: Partial<T>;
+	options?: PineOptionsFor<T>;
+}
+
+export interface PineParamsWithIdFor<T> extends PineParamsFor<T> {
+	id: number;
+}

--- a/typings/resin-pine.d.ts
+++ b/typings/resin-pine.d.ts
@@ -1,17 +1,17 @@
 import * as Promise from 'bluebird';
-import * as ResinSdk from './resin-sdk';
+import * as PineClient from './pinejs-client-core';
 
 /* tslint:disable:no-namespace */
 declare namespace ResinPine {
 	interface Pine {
 		delete<T>(
-			params: ResinSdk.PineParamsWithIdFor<T> | ResinSdk.PineParamsFor<T>,
+			params: PineClient.PineParamsWithIdFor<T> | PineClient.PineParamsFor<T>,
 		): Promise<string>;
-		get<T>(params: ResinSdk.PineParamsWithIdFor<T>): Promise<T>;
-		get<T>(params: ResinSdk.PineParamsFor<T>): Promise<T[]>;
-		get<T, Result>(params: ResinSdk.PineParamsFor<T>): Promise<Result>;
-		post<T>(params: ResinSdk.PineParams): Promise<T>;
-		patch<T>(params: ResinSdk.PineParams): Promise<T>;
+		get<T>(params: PineClient.PineParamsWithIdFor<T>): Promise<T>;
+		get<T>(params: PineClient.PineParamsFor<T>): Promise<T[]>;
+		get<T, Result>(params: PineClient.PineParamsFor<T>): Promise<Result>;
+		post<T>(params: PineClient.PineParams): Promise<T>;
+		patch<T>(params: PineClient.PineParams): Promise<T>;
 	}
 }
 

--- a/typings/resin-sdk.d.ts
+++ b/typings/resin-sdk.d.ts
@@ -8,6 +8,20 @@ import { ResinRequest } from './resin-request';
 
 /* tslint:disable:no-namespace */
 declare namespace ResinSdk {
+	type WithId = Pine.WithId;
+	type PineDeferred = Pine.PineDeferred;
+	type NavigationResource<T = WithId> = Pine.NavigationResource<T>;
+	type ReverseNavigationResource<T = WithId> = Pine.ReverseNavigationResource<
+		T
+	>;
+	type PineFilterFor<T> = Pine.Filter<T>;
+	type PineExpandFor<T> = Pine.Expand<T>;
+	type PineOptions = Pine.PineOptions;
+	type PineOptionsFor<T> = Pine.PineOptionsFor<T>;
+	type PineParams = Pine.PineParams;
+	type PineParamsFor<T> = Pine.PineParamsFor<T>;
+	type PineParamsWithIdFor<T> = Pine.PineParamsWithIdFor<T>;
+
 	interface Interceptor {
 		request?(response: any): Promise<any>;
 		response?(response: any): Promise<any>;
@@ -132,62 +146,6 @@ declare namespace ResinSdk {
 		choices?: string[] | number[];
 		choicesLabels?: { [key: string]: string };
 	}
-
-	interface WithId {
-		id: number;
-	}
-
-	interface PineParams {
-		resource: string;
-		id?: number;
-		body?: object;
-		options?: PineOptions;
-	}
-
-	interface PineOptions {
-		$filter?: object;
-		$expand?: object | string;
-		$orderBy?: Pine.OrderBy;
-		$top?: number;
-		$skip?: number;
-		$select?: string | string[];
-	}
-
-	interface PineParamsFor<T> extends PineParams {
-		body?: Partial<T>;
-		options?: PineOptionsFor<T>;
-	}
-
-	interface PineParamsWithIdFor<T> extends PineParamsFor<T> {
-		id: number;
-	}
-
-	type PineFilterFor<T> = Pine.Filter<T>;
-	type PineExpandFor<T> = Pine.Expand<T>;
-
-	interface PineOptionsFor<T> extends PineOptions {
-		$filter?: PineFilterFor<T>;
-		$expand?: PineExpandFor<T>;
-		$select?: Array<keyof T> | keyof T | '*';
-		$orderby?: string;
-	}
-
-	interface PineDeferred {
-		__id: number;
-	}
-
-	/**
-	 * When not selected-out holds a deferred.
-	 * When expanded hold an array with a single element.
-	 */
-	type NavigationResource<T = WithId> = T[] | PineDeferred;
-
-	/**
-	 * When expanded holds an array, otherwise the property is not present.
-	 * Selecting is not suggested,
-	 * in that case it holds a deferred to the original resource.
-	 */
-	type ReverseNavigationResource<T = WithId> = T[] | undefined;
 
 	interface SocialServiceAccount {
 		provider: string;


### PR DESCRIPTION
This is still compatible with previous versions on TS.
Also moves some of the Pine related typings in the pine client file but still re-exports them to avoid a breaking change.

Resolves: #550
Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@resin.io>