### PR TITLE
Deprecate generate api key

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -31,7 +31,7 @@ If you feel something is missing, not clear or could be improved, please don't h
             * [.create(options)](#resin.models.application.create) ⇒ <code>Promise</code>
             * [.remove(nameOrId)](#resin.models.application.remove) ⇒ <code>Promise</code>
             * [.restart(nameOrId)](#resin.models.application.restart) ⇒ <code>Promise</code>
-            * [.generateApiKey(nameOrId)](#resin.models.application.generateApiKey) ⇒ <code>Promise</code>
+            * ~~[.generateApiKey(nameOrId)](#resin.models.application.generateApiKey) ⇒ <code>Promise</code>~~
             * [.generateProvisioningKey(nameOrId)](#resin.models.application.generateProvisioningKey) ⇒ <code>Promise</code>
             * [.purge(appId)](#resin.models.application.purge) ⇒ <code>Promise</code>
             * [.shutdown(appId, [options])](#resin.models.application.shutdown) ⇒ <code>Promise</code>
@@ -280,7 +280,7 @@ resin.models.device.get(123).catch(function (error) {
         * [.create(options)](#resin.models.application.create) ⇒ <code>Promise</code>
         * [.remove(nameOrId)](#resin.models.application.remove) ⇒ <code>Promise</code>
         * [.restart(nameOrId)](#resin.models.application.restart) ⇒ <code>Promise</code>
-        * [.generateApiKey(nameOrId)](#resin.models.application.generateApiKey) ⇒ <code>Promise</code>
+        * ~~[.generateApiKey(nameOrId)](#resin.models.application.generateApiKey) ⇒ <code>Promise</code>~~
         * [.generateProvisioningKey(nameOrId)](#resin.models.application.generateProvisioningKey) ⇒ <code>Promise</code>
         * [.purge(appId)](#resin.models.application.purge) ⇒ <code>Promise</code>
         * [.shutdown(appId, [options])](#resin.models.application.shutdown) ⇒ <code>Promise</code>
@@ -407,7 +407,7 @@ resin.models.device.get(123).catch(function (error) {
     * [.create(options)](#resin.models.application.create) ⇒ <code>Promise</code>
     * [.remove(nameOrId)](#resin.models.application.remove) ⇒ <code>Promise</code>
     * [.restart(nameOrId)](#resin.models.application.restart) ⇒ <code>Promise</code>
-    * [.generateApiKey(nameOrId)](#resin.models.application.generateApiKey) ⇒ <code>Promise</code>
+    * ~~[.generateApiKey(nameOrId)](#resin.models.application.generateApiKey) ⇒ <code>Promise</code>~~
     * [.generateProvisioningKey(nameOrId)](#resin.models.application.generateProvisioningKey) ⇒ <code>Promise</code>
     * [.purge(appId)](#resin.models.application.purge) ⇒ <code>Promise</code>
     * [.shutdown(appId, [options])](#resin.models.application.shutdown) ⇒ <code>Promise</code>
@@ -787,7 +787,9 @@ resin.models.application.restart('MyApp', function(error) {
 ```
 <a name="resin.models.application.generateApiKey"></a>
 
-##### application.generateApiKey(nameOrId) ⇒ <code>Promise</code>
+##### ~~application.generateApiKey(nameOrId) ⇒ <code>Promise</code>~~
+***Deprecated***
+
 Generally you shouldn't use this method: if you're provisioning a recent ResinOS
 version (2.4.0+) then generateProvisioningKey should work just as well, but
 be more secure.

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1500,6 +1500,8 @@ resin.models.device.getApplicationName('7cf02a6', function(error, applicationNam
 ##### ~~device.getApplicationInfo(uuidOrId) ⇒ <code>Promise</code>~~
 ***Deprecated***
 
+This is not supported on multicontainer devices, and will be removed in a future major release
+
 **Kind**: static method of [<code>device</code>](#resin.models.device)  
 **Summary**: Get application container information  
 **Access**: public  
@@ -1817,6 +1819,8 @@ resin.models.device.move('7cf02a6', 'MyApp', function(error) {
 ##### ~~device.startApplication(uuidOrId) ⇒ <code>Promise</code>~~
 ***Deprecated***
 
+This is not supported on multicontainer devices, and will be removed in a future major release
+
 **Kind**: static method of [<code>device</code>](#resin.models.device)  
 **Summary**: Start application on device  
 **Access**: public  
@@ -1849,6 +1853,8 @@ resin.models.device.startApplication('7cf02a6', function(error, containerId) {
 
 ##### ~~device.stopApplication(uuidOrId) ⇒ <code>Promise</code>~~
 ***Deprecated***
+
+This is not supported on multicontainer devices, and will be removed in a future major release
 
 **Kind**: static method of [<code>device</code>](#resin.models.device)  
 **Summary**: Stop application on device  

--- a/lib/models/application.coffee
+++ b/lib/models/application.coffee
@@ -495,6 +495,7 @@ getApplicationModel = (deps, opts) ->
 	# @public
 	# @function
 	# @memberof resin.models.application
+	# @deprecated
 	# @description
 	# Generally you shouldn't use this method: if you're provisioning a recent ResinOS
 	# version (2.4.0+) then generateProvisioningKey should work just as well, but

--- a/lib/models/device.coffee
+++ b/lib/models/device.coffee
@@ -458,8 +458,8 @@ getDeviceModel = (deps, opts) ->
 	# @memberof resin.models.device
 	#
 	# @deprecated
-	# This is not supported on multicontainer devices, and will
-	# be removed in a future major release
+	# @description
+	# This is not supported on multicontainer devices, and will be removed in a future major release
 	#
 	# @param {String|Number} uuidOrId - device uuid (string) or id (number)
 	# @fulfil {Object} - application info
@@ -860,8 +860,8 @@ getDeviceModel = (deps, opts) ->
 	# @memberof resin.models.device
 	#
 	# @deprecated
-	# This is not supported on multicontainer devices, and will
-	# be removed in a future major release
+	# @description
+	# This is not supported on multicontainer devices, and will be removed in a future major release
 	#
 	# @param {String|Number} uuidOrId - device uuid (string) or id (number)
 	# @fulfil {String} - application container id
@@ -910,8 +910,8 @@ getDeviceModel = (deps, opts) ->
 	# @memberof resin.models.device
 	#
 	# @deprecated
-	# This is not supported on multicontainer devices, and will
-	# be removed in a future major release
+	# @description
+	# This is not supported on multicontainer devices, and will be removed in a future major release
 	#
 	# @param {String|Number} uuidOrId - device uuid (string) or id (number)
 	# @fulfil {String} - application container id


### PR DESCRIPTION
Mark generateApiKey as deprecated - nowadays nobody should be using this, and we should be explicit about that.

Also fix the deprecation warnings on the supervisor methods, since I noticed here that they haven't been adding the message into the docs properly.