### PR TITLE
typings: Allow numeric parameters to models.application.has()

### DIFF
--- a/typings/resin-sdk.d.ts
+++ b/typings/resin-sdk.d.ts
@@ -621,7 +621,7 @@ declare namespace ResinSdk {
 					options?: PineOptionsFor<Application>,
 				): Promise<Application>;
 				getAll(options?: PineOptionsFor<Application>): Promise<Application[]>;
-				has(name: string): Promise<boolean>;
+				has(nameOrId: string | number): Promise<boolean>;
 				hasAny(): Promise<boolean>;
 				remove(nameOrId: string | number): Promise<void>;
 				restart(nameOrId: string | number): Promise<void>;


### PR DESCRIPTION
Resolves: #567
See: https://github.com/resin-io/resin-sdk/blob/f5de14600579f8e0df1c4b550b4fd185611ea123/lib/models/application.coffee#L329
See: https://github.com/resin-io/resin-sdk/blob/f5de14600579f8e0df1c4b550b4fd185611ea123/tests/integration/models/application.spec.coffee#L196
Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@resin.io>