### PR TITLE
Print a deprecation warning message when using the unrenamed SDK

### DIFF
--- a/lib/resin.coffee
+++ b/lib/resin.coffee
@@ -21,7 +21,9 @@ getRequest = require('resin-request')
 ResinAuth = require('resin-auth')['default']
 getPine = require('resin-pine')
 errors = require('resin-errors')
+
 { notImplemented, globalEnv } = require('./util')
+deprecationWarnings = require('./util/deprecation-warnings')
 
 # These constants are used to create globals for sharing defualt options between
 # multiple instances of the SDK.
@@ -66,6 +68,8 @@ sdkTemplate =
 	settings: require('./settings')
 
 getSdk = (opts = {}) ->
+	deprecationWarnings.resinRenameDeprecation()
+
 	defaults opts,
 		apiUrl: 'https://api.resin.io/'
 		imageMakerUrl: 'https://img.resin.io/'

--- a/lib/util/deprecation-warnings.ts
+++ b/lib/util/deprecation-warnings.ts
@@ -3,10 +3,10 @@ import * as _ from 'lodash';
 
 export = _.mapValues(
 	{
-		pubNubDeprecated: () =>
+		resinRenameDeprecation: () =>
 			console.error(stripIndent`
-				Warning: using legacy logging services, this will stop working shortly.
-				Please update to ensure logs are correctly retrieved in future.
+				Warning: 'resin-sdk' is now 'balena-sdk'.
+				Please update your dependencies to continue receiving new updates.
 			`),
 	},
 	_.once,


### PR DESCRIPTION
Before merging the final fix to https://github.com/resin-io/resin-sdk/issues/587, we should merge this to publish a tombstone release of resin-sdk that warns users to upgrade. 

This PR does that, printing a deprecation warning message the first time the SDK is instantiated. En route, it removes a leftover deprecation warning from the pubnub migration work.

We should not merge/publish this PR until the main rename is in PR and ready to merge & release directly afterwards.

Fixes #588 
Change-type: patch
Signed-off-by: Tim Perry <tim@resin.io>