### PR TITLE
Use the API for images & device types

### DIFF
--- a/lib/models/os.coffee
+++ b/lib/models/os.coffee
@@ -23,7 +23,17 @@ _ = require('lodash')
 
 errors = require('resin-errors')
 
-{ onlyIf, getImgMakerHelper, findCallback, notFoundResponse, treatAsMissingApplication, deviceTypes: deviceTypesUtil, osVersionRCompare, isDevelopmentVersion } = require('../util')
+{
+	onlyIf
+	getImgMakerHelper
+	getUnauthenticatedRequestHelper
+	findCallback
+	notFoundResponse
+	treatAsMissingApplication
+	deviceTypes: deviceTypesUtil
+	osVersionRCompare
+	isDevelopmentVersion
+} = require('../util')
 
 RESINOS_VERSION_REGEX = /v?\d+\.\d+\.\d+(\.rev\d+)?((\-|\+).+)?/
 
@@ -31,6 +41,7 @@ getOsModel = (deps, opts) ->
 	{ request } = deps
 	{ apiUrl, isBrowser, imageMakerUrl } = opts
 
+	unauthenticatedRequestHelper = getUnauthenticatedRequestHelper(apiUrl, request)
 	imgMakerHelper = getImgMakerHelper(imageMakerUrl, request)
 
 	configModel = once -> require('./config')(deps, opts)
@@ -44,12 +55,12 @@ getOsModel = (deps, opts) ->
 		.then (types) ->
 			!!deviceTypesUtil.findBySlug(types, deviceType)
 
-	getDownloadSize = imgMakerHelper.buildApiRequester
-		buildUrl: ({ deviceType, version }) -> "/size_estimate?deviceType=#{deviceType}&version=#{version}"
+	getDownloadSize = unauthenticatedRequestHelper.buildMemoizedApiRequester
+		buildUrl: ({ deviceType, version }) -> "/download-size?deviceType=#{deviceType}&version=#{version}"
 		postProcess: ({ body }) -> body.size
 
-	getOsVersions = imgMakerHelper.buildApiRequester
-		buildUrl: ({ deviceType }) -> "/image/#{deviceType}/versions"
+	getOsVersions = unauthenticatedRequestHelper.buildMemoizedApiRequester
+		buildUrl: ({ deviceType }) -> "/images/v1/#{deviceType}/versions"
 		postProcess: ({ body: { versions, latest } }) ->
 
 			versions.sort(osVersionRCompare)

--- a/lib/util/image-maker.coffee
+++ b/lib/util/image-maker.coffee
@@ -1,0 +1,21 @@
+assign = require('lodash/assign')
+getUnauthenticatedRequestHelper = require('./unauthenticated-request-helper')
+
+IMG_MAKER_API_VERSION = '1'
+IMG_MAKER_API_PREFIX = "/api/v#{IMG_MAKER_API_VERSION}"
+
+DEFAULT_RESULTS_CACHING_INTERVAL = 10 * 60 * 1000 # 10 minutes
+
+getImageMakerHelper = (baseUrl, request) ->
+	exports = getUnauthenticatedRequestHelper(baseUrl, request)
+
+	baseBuildOptions = exports.buildOptions
+
+	exports.buildOptions = (options) ->
+		{ url } = options
+		url = "#{IMG_MAKER_API_PREFIX}#{url}"
+		return assign(baseBuildOptions(options), { url })
+
+	return exports
+
+module.exports = getImageMakerHelper

--- a/lib/util/index.coffee
+++ b/lib/util/index.coffee
@@ -27,7 +27,8 @@ else null # If we can't guarantee global state, don't fake it: fail instead.
 
 
 exports.deviceTypes = require('./device-types')
-exports.getImgMakerHelper = require('./img-maker')
+exports.getImgMakerHelper = require('./image-maker')
+exports.getUnauthenticatedRequestHelper = require('./unauthenticated-request-helper')
 
 exports.notImplemented = notImplemented = ->
 	throw new Error('The method is not implemented.')

--- a/lib/util/unauthenticated-request-helper.coffee
+++ b/lib/util/unauthenticated-request-helper.coffee
@@ -1,32 +1,26 @@
 assign = require('lodash/assign')
 promiseMemoize = require('promise-memoize')
 
-IMG_MAKER_API_VERSION = '1'
-IMG_MAKER_API_PREFIX = "/api/v#{IMG_MAKER_API_VERSION}"
-
 DEFAULT_RESULTS_CACHING_INTERVAL = 10 * 60 * 1000 # 10 minutes
 
-getImgMakerHelper = (imageMakerUrl, request) ->
+getUnauthenticatedRequestHelper = (baseUrl, request) ->
 	exports = {}
 
-	buildOptions = (options) ->
-		{ url } = options
-		url = "#{IMG_MAKER_API_PREFIX}#{url}"
-
+	exports.buildOptions = (options) ->
 		return assign(
 			{ method: 'GET' },
 			options,
-			{ url, baseUrl: imageMakerUrl, sendToken: false }
+			{ baseUrl, sendToken: false }
 		)
 
 	exports.request = sendRequest = (options) ->
-		request.send(buildOptions(options))
+		request.send(exports.buildOptions(options))
 
 	exports.stream = (options) ->
-		request.stream(buildOptions(options))
+		request.stream(exports.buildOptions(options))
 
 	# NB: for the sake of memoization currently only works with GET requests
-	exports.buildApiRequester = ({
+	exports.buildMemoizedApiRequester = ({
 		buildUrl,
 		postProcess = (x) -> x,
 		onError = (x) -> throw x,
@@ -54,4 +48,4 @@ getImgMakerHelper = (imageMakerUrl, request) ->
 
 	return exports
 
-module.exports = getImgMakerHelper
+module.exports = getUnauthenticatedRequestHelper

--- a/tests/util.spec.coffee
+++ b/tests/util.spec.coffee
@@ -193,7 +193,7 @@ describe 'ImgMakerHelper', ->
 		@imgMakerHelper = getImgMakerHelper(ROOT_URL, @requestStub)
 
 	it 'should build API requesters', =>
-		requester = @imgMakerHelper.buildApiRequester
+		requester = @imgMakerHelper.buildMemoizedApiRequester
 			buildUrl: ({ deviceType, version }) ->
 				"/endpoint?d=#{deviceType}&v=#{version}"
 
@@ -205,7 +205,7 @@ describe 'ImgMakerHelper', ->
 			url: '/api/v1/endpoint?d=raspberrypi3&v=1.24.0'
 
 	it 'should cache reponses', =>
-		requester = @imgMakerHelper.buildApiRequester
+		requester = @imgMakerHelper.buildMemoizedApiRequester
 			buildUrl: ({ deviceType, version }) ->
 				"/endpoint?d=#{deviceType}&v=#{version}"
 


### PR DESCRIPTION
This makes the calls related to device types & image listing to target the API instead of the image maker.
PS: The `os.download()` and `os.getLastModified()` method are still targeting the image maker.

Resolves: #591
Change-type: minor
Depends-on: https://github.com/resin-io/resin-api/issues/1536
HQ: https://github.com/resin-io/balena/pull/1140
Signed-off-by: Thodoris Greasidis <thodoris@resin.io>