### PR TITLE
application.getAll: Use the my_application endpoint

### DIFF
--- a/lib/models/application.coffee
+++ b/lib/models/application.coffee
@@ -117,16 +117,10 @@ getApplicationModel = (deps, opts) ->
 		auth.getUserId()
 		.then (userId) ->
 			return pine.get
-				resource: 'application'
+				resource: 'my_application'
 				options:
 					mergePineOptions
 						$orderby: 'app_name asc'
-						$filter:
-							$or:
-								user: userId
-								includes__user: $any:
-									$alias: 'x'
-									$expr: x: user: userId
 					, options
 
 		.map (application) ->


### PR DESCRIPTION
With this change the application.getAll() will use the my_application 
endpoint instead of defining pine filters. This will also stops it from
returning dependent applications.

Change-type: major
HQ: https://github.com/resin-io/balena/pull/1140
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>